### PR TITLE
Get rid of prefix in TButtons enum type

### DIFF
--- a/PLC_esp8266/main/LogicProgram/Controller.cpp
+++ b/PLC_esp8266/main/LogicProgram/Controller.cpp
@@ -99,19 +99,19 @@ void Controller::ProcessTask(void *parm) {
         bool buttons_changed = !inputs_changed && uxBits != 0;
 
         if (buttons_changed) {
-            TButtons pressed_button = handle_buttons(uxBits);
+            ButtonsPressType pressed_button = handle_buttons(uxBits);
             ESP_LOGD(TAG_Controller, "buttons_changed, pressed_button:%u", pressed_button);
             switch (pressed_button) {
-                case TButtons::UP_PRESSED:
+                case ButtonsPressType::UP_PRESSED:
                     xTaskNotify(render_task_handle, DO_SCROLL_UP, eNotifyAction::eSetBits);
                     break;
-                case TButtons::DOWN_PRESSED:
+                case ButtonsPressType::DOWN_PRESSED:
                     xTaskNotify(render_task_handle, DO_SCROLL_DOWN, eNotifyAction::eSetBits);
                     break;
-                case TButtons::SELECT_PRESSED:
+                case ButtonsPressType::SELECT_PRESSED:
                     xTaskNotify(render_task_handle, DO_SELECT, eNotifyAction::eSetBits);
                     break;
-                case TButtons::SELECT_LONG_PRESSED:
+                case ButtonsPressType::SELECT_LONG_PRESSED:
                     xTaskNotify(render_task_handle, DO_SELECT_OPTION, eNotifyAction::eSetBits);
                     break;
                 default:

--- a/PLC_esp8266/main/button.cpp
+++ b/PLC_esp8266/main/button.cpp
@@ -5,8 +5,8 @@
 button::button(const char *tag,
                EventBits_t close_bit,
                EventBits_t open_bit,
-               TButtons pressed_type,
-               TButtons long_pressed_type) {
+               ButtonsPressType pressed_type,
+               ButtonsPressType long_pressed_type) {
     this->TAG = tag;
     this->close_bit = close_bit;
     this->open_bit = open_bit;

--- a/PLC_esp8266/main/button.h
+++ b/PLC_esp8266/main/button.h
@@ -26,14 +26,14 @@ class button {
         btLongPressed = 0x08,
     };
     const char *TAG;
-    TButtons pressed_type;
-    TButtons long_pressed_type;
+    ButtonsPressType pressed_type;
+    ButtonsPressType long_pressed_type;
 
     button(const char *tag,
            EventBits_t close_bit,
            EventBits_t open_bit,
-           TButtons pressed_type,
-           TButtons long_pressed_type);
+           ButtonsPressType pressed_type,
+           ButtonsPressType long_pressed_type);
 
     state handle(EventBits_t bits);
 };

--- a/PLC_esp8266/main/buttons.cpp
+++ b/PLC_esp8266/main/buttons.cpp
@@ -13,27 +13,27 @@ static struct {
         { button("button UP",
                  BUTTON_UP_IO_CLOSE,
                  BUTTON_UP_IO_OPEN,
-                 TButtons::UP_PRESSED,
-                 TButtons::UP_LONG_PRESSED) },
+                 ButtonsPressType::UP_PRESSED,
+                 ButtonsPressType::UP_LONG_PRESSED) },
         { button("button DOWN",
                  BUTTON_DOWN_IO_CLOSE,
                  BUTTON_DOWN_IO_OPEN,
-                 TButtons::DOWN_PRESSED,
-                 TButtons::DOWN_LONG_PRESSED) },
+                 ButtonsPressType::DOWN_PRESSED,
+                 ButtonsPressType::DOWN_LONG_PRESSED) },
         { button("button RIGHT",
                  BUTTON_RIGHT_IO_CLOSE,
                  BUTTON_RIGHT_IO_OPEN,
-                 TButtons::RIGHT_PRESSED,
-                 TButtons::RIGHT_LONG_PRESSED) },
+                 ButtonsPressType::RIGHT_PRESSED,
+                 ButtonsPressType::RIGHT_LONG_PRESSED) },
         { button("button SELECT",
                  BUTTON_SELECT_IO_CLOSE,
                  BUTTON_SELECT_IO_OPEN,
-                 TButtons::SELECT_PRESSED,
-                 TButtons::SELECT_LONG_PRESSED) },
+                 ButtonsPressType::SELECT_PRESSED,
+                 ButtonsPressType::SELECT_LONG_PRESSED) },
     };
 } buttons;
 
-TButtons handle_buttons(EventBits_t uxBits) {
+ButtonsPressType handle_buttons(EventBits_t uxBits) {
     for (auto &button : buttons.buttons) {
         switch (button.handle(uxBits)) {
             case button::state::btDown:
@@ -55,5 +55,5 @@ TButtons handle_buttons(EventBits_t uxBits) {
                 break;
         }
     }
-    return TButtons::NOTHING_PRESSED;
+    return ButtonsPressType::NOTHING_PRESSED;
 }

--- a/PLC_esp8266/main/buttons.h
+++ b/PLC_esp8266/main/buttons.h
@@ -16,12 +16,12 @@ typedef enum { //
     RIGHT_LONG_PRESSED,
     SELECT_PRESSED,
     SELECT_LONG_PRESSED
-} TButtons;
+} ButtonsPressType;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-TButtons handle_buttons(EventBits_t uxBits);
+ButtonsPressType handle_buttons(EventBits_t uxBits);
 
 #ifdef __cplusplus
 }

--- a/Tests_esp8266/src/button_tests.cpp
+++ b/Tests_esp8266/src/button_tests.cpp
@@ -27,8 +27,8 @@ TEST(ButtonTestsGroup, handle_btDown) {
     button testable("test",
                     BUTTON_UP_IO_CLOSE,
                     BUTTON_UP_IO_OPEN,
-                    TButtons::NOTHING_PRESSED,
-                    TButtons::NOTHING_PRESSED);
+                    ButtonsPressType::NOTHING_PRESSED,
+                    ButtonsPressType::NOTHING_PRESSED);
 
     auto state = testable.handle(BUTTON_UP_IO_CLOSE);
     CHECK_EQUAL(button::state::btDown, state);
@@ -44,8 +44,8 @@ TEST(ButtonTestsGroup, handle_with_unfamiliar_bits_nothing_to_do) {
     button testable("test",
                     BUTTON_UP_IO_CLOSE,
                     BUTTON_UP_IO_OPEN,
-                    TButtons::NOTHING_PRESSED,
-                    TButtons::NOTHING_PRESSED);
+                    ButtonsPressType::NOTHING_PRESSED,
+                    ButtonsPressType::NOTHING_PRESSED);
 
     auto state = testable.handle(BUTTON_DOWN_IO_CLOSE);
     CHECK_EQUAL(button::state::btNone, state);
@@ -63,8 +63,8 @@ TEST(ButtonTestsGroup, handle_normal_press) {
     button testable("test",
                     BUTTON_UP_IO_CLOSE,
                     BUTTON_UP_IO_OPEN,
-                    TButtons::NOTHING_PRESSED,
-                    TButtons::NOTHING_PRESSED);
+                    ButtonsPressType::NOTHING_PRESSED,
+                    ButtonsPressType::NOTHING_PRESSED);
 
     auto state = testable.handle(BUTTON_UP_IO_CLOSE);
     CHECK_EQUAL(button::state::btDown, state);
@@ -83,8 +83,8 @@ TEST(ButtonTestsGroup, handle_press_when_os_us_overflowed) {
     button testable("test",
                     BUTTON_UP_IO_CLOSE,
                     BUTTON_UP_IO_OPEN,
-                    TButtons::NOTHING_PRESSED,
-                    TButtons::NOTHING_PRESSED);
+                    ButtonsPressType::NOTHING_PRESSED,
+                    ButtonsPressType::NOTHING_PRESSED);
 
     auto state = testable.handle(BUTTON_UP_IO_CLOSE);
     CHECK_EQUAL(button::state::btDown, state);
@@ -103,8 +103,8 @@ TEST(ButtonTestsGroup, handle_longpress_when_os_us_overflowed) {
     button testable("test",
                     BUTTON_UP_IO_CLOSE,
                     BUTTON_UP_IO_OPEN,
-                    TButtons::NOTHING_PRESSED,
-                    TButtons::NOTHING_PRESSED);
+                    ButtonsPressType::NOTHING_PRESSED,
+                    ButtonsPressType::NOTHING_PRESSED);
 
     auto state = testable.handle(BUTTON_UP_IO_CLOSE);
     CHECK_EQUAL(button::state::btDown, state);
@@ -123,8 +123,8 @@ TEST(ButtonTestsGroup, handle_short_press) {
     button testable("test",
                     BUTTON_UP_IO_CLOSE,
                     BUTTON_UP_IO_OPEN,
-                    TButtons::NOTHING_PRESSED,
-                    TButtons::NOTHING_PRESSED);
+                    ButtonsPressType::NOTHING_PRESSED,
+                    ButtonsPressType::NOTHING_PRESSED);
 
     auto state = testable.handle(BUTTON_UP_IO_CLOSE);
     CHECK_EQUAL(button::state::btDown, state);


### PR DESCRIPTION
TButtons enum type name doesn't tell anything about which it enumerates, so renamed it to ButtonsPressType for better readability.