### PR TITLE
Element box elements ordering

### DIFF
--- a/PLC_esp8266/main/LogicProgram/ElementsBox.cpp
+++ b/PLC_esp8266/main/LogicProgram/ElementsBox.cpp
@@ -22,7 +22,6 @@ static const char *TAG_ElementsBox = "ElementsBox";
 ElementsBox::ElementsBox(uint8_t fill_wire, LogicElement *source_element, bool hide_output_elements)
     : LogicElement() {
     this->place_width = CalcEntirePlaceWidth(fill_wire, source_element);
-    // this->source_element = source_element;
     source_element->BeginEditing();
     selected_index = 0;
     force_do_action_result = false;
@@ -30,14 +29,8 @@ ElementsBox::ElementsBox(uint8_t fill_wire, LogicElement *source_element, bool h
 }
 
 ElementsBox::~ElementsBox() {
-    /* if (Editing()) {
-         delete source_element;
-     } else  if (GetSelectedElement() != source_element)*/
-    {
-        auto selected_it = std::find(begin(), end(), GetSelectedElement());
-        erase(selected_it);
-        // delete source_element;
-    }
+    auto selected_it = std::find(begin(), end(), GetSelectedElement());
+    erase(selected_it);
 
     while (!empty()) {
         auto it = begin();
@@ -241,9 +234,6 @@ void ElementsBox::Fill(LogicElement *source_element, bool hide_output_elements) 
 }
 
 LogicElement *ElementsBox::GetSelectedElement() {
-    // if (selected_index < 0) {
-    //     return source_element;
-    // }
     return (*this)[selected_index];
 }
 

--- a/PLC_esp8266/main/LogicProgram/ElementsBox.h
+++ b/PLC_esp8266/main/LogicProgram/ElementsBox.h
@@ -11,22 +11,21 @@
 class ElementsBox : public LogicElement, public std::vector<LogicElement *> {
   protected:
     uint8_t place_width;
-    uint8_t stored_element_width;
-    LogicElement *stored_element;
+    uint8_t source_element_width;    
     int selected_index;
     bool force_do_action_result;
 
-    uint8_t CalcEntirePlaceWidth(uint8_t fill_wire, LogicElement *stored_element);
-    void Fill(bool hide_output_elements);
-    void AppendStandartElement(TvElementType element_type, uint8_t *frame_buffer);
-    bool MatchedToStoredElement(TvElementType element_type);
-    bool CopyParamsToCommonInput(CommonInput *common_input);
-    bool CopyParamsToCommonTimer(CommonTimer *common_timer);
-    bool CopyParamsToCommonOutput(CommonOutput *common_output);
-    void TakeParamsFromStoredElement(LogicElement *new_element);
+    uint8_t CalcEntirePlaceWidth(uint8_t fill_wire, LogicElement *source_element);
+    void Fill(LogicElement *source_element, bool hide_output_elements);
+    void AppendStandartElement(LogicElement *source_element, TvElementType element_type, uint8_t *frame_buffer);
+    bool MatchedToStoredElement(LogicElement *source_element, TvElementType element_type);
+    bool CopyParamsToCommonInput(LogicElement *source_element, CommonInput *common_input);
+    bool CopyParamsToCommonTimer(LogicElement *source_element, CommonTimer *common_timer);
+    bool CopyParamsToCommonOutput(LogicElement *source_element, CommonOutput *common_output);
+    void TakeParamsFromStoredElement(LogicElement *source_element, LogicElement *new_element);
 
   public:
-    ElementsBox(uint8_t fill_wire, LogicElement *stored_element, bool hide_output_elements);
+    ElementsBox(uint8_t fill_wire, LogicElement *source_element, bool hide_output_elements);
     virtual ~ElementsBox();
 
     LogicElement *GetSelectedElement();

--- a/PLC_esp8266/main/LogicProgram/LogicElement.cpp
+++ b/PLC_esp8266/main/LogicProgram/LogicElement.cpp
@@ -11,3 +11,7 @@ LogicElement::LogicElement() : EditableElement() {
 
 LogicElement::~LogicElement() {
 }
+
+LogicItemState LogicElement::GetState() {
+    return state;
+}

--- a/PLC_esp8266/main/LogicProgram/LogicElement.h
+++ b/PLC_esp8266/main/LogicProgram/LogicElement.h
@@ -27,6 +27,8 @@ class LogicElement : public EditableElement {
     LogicElement();
     virtual ~LogicElement();
 
+    LogicItemState GetState();
+    
     virtual bool DoAction(bool prev_elem_changed, LogicItemState prev_elem_state) = 0;
     virtual bool Render(uint8_t *fb, LogicItemState prev_elem_state, Point *start_point) = 0;
 

--- a/PLC_esp8266/main/LogicProgram/Network.cpp
+++ b/PLC_esp8266/main/LogicProgram/Network.cpp
@@ -329,13 +329,21 @@ bool Network::EnoughSpaceForNewElement(LogicElement *new_element) {
     bool hide_output_elements = HasOutputElement();
     ElementsBox elementBox(fill_wire, new_element, hide_output_elements);
     new_element->EndEditing();
-    bool res = elementBox.size() > 0;
+    bool not_enough =
+        elementBox.size() == 0
+        || (elementBox.size() == 1
+            && elementBox.GetSelectedElement()->GetElementType() == TvElementType::et_Wire);
     delete elementBox.GetSelectedElement();
-    return res;
+    return !not_enough;
 }
 
 void Network::AddSpaceForNewElement() {
     auto wire = new Wire();
+    uint8_t wire_width = fill_wire / 2 + 1;
+    if (wire_width > WIRE_STANDART_WIDTH) {
+        wire_width = WIRE_STANDART_WIDTH;
+    }
+    wire->SetWidth(wire_width);
     if (EnoughSpaceForNewElement(wire)) {
         ESP_LOGI(TAG_Network, "insert wire element");
 
@@ -349,11 +357,6 @@ void Network::AddSpaceForNewElement() {
             }
             it++;
         }
-        uint8_t wire_width = fill_wire / 2 + 1;
-        if (wire_width > WIRE_STANDART_WIDTH) {
-            wire_width = WIRE_STANDART_WIDTH;
-        }
-        wire->SetWidth(wire_width);
         insert(it, wire);
 
     } else {

--- a/PLC_esp8266/main/LogicProgram/Network.cpp
+++ b/PLC_esp8266/main/LogicProgram/Network.cpp
@@ -301,12 +301,13 @@ void Network::Change() {
     }
 
     if ((*this)[selected_element]->Selected()) {
-        auto stored_element = (*this)[selected_element];
+        auto source_element = (*this)[selected_element];
         bool hide_output_elements = HasOutputElement();
         ESP_LOGI(TAG_Network, "hide_output_elements:%u", hide_output_elements);
-        auto elementBox = new ElementsBox(fill_wire, stored_element, hide_output_elements);
+        auto elementBox = new ElementsBox(fill_wire, source_element, hide_output_elements);
         elementBox->BeginEditing();
         (*this)[selected_element] = elementBox;
+        delete source_element;
 
     } else if ((*this)[selected_element]->Editing()) {
         auto elementBox = static_cast<ElementsBox *>((*this)[selected_element]);
@@ -328,7 +329,9 @@ bool Network::EnoughSpaceForNewElement(LogicElement *new_element) {
     bool hide_output_elements = HasOutputElement();
     ElementsBox elementBox(fill_wire, new_element, hide_output_elements);
     new_element->EndEditing();
-    return elementBox.size() > 0;
+    bool res = elementBox.size() > 0;
+    delete elementBox.GetSelectedElement();
+    return res;
 }
 
 void Network::AddSpaceForNewElement() {

--- a/PLC_esp8266/main/LogicProgram/Network.cpp
+++ b/PLC_esp8266/main/LogicProgram/Network.cpp
@@ -302,7 +302,7 @@ void Network::Change() {
 
     if ((*this)[selected_element]->Selected()) {
         auto source_element = (*this)[selected_element];
-        bool hide_output_elements = HasOutputElement();
+        bool hide_output_elements = HasOutputElement() && CommonOutput::TryToCast(source_element) == NULL;
         ESP_LOGI(TAG_Network, "hide_output_elements:%u", hide_output_elements);
         auto elementBox = new ElementsBox(fill_wire, source_element, hide_output_elements);
         elementBox->BeginEditing();

--- a/PLC_esp8266/main/LogicProgram/Outputs/DecOutput.cpp
+++ b/PLC_esp8266/main/LogicProgram/Outputs/DecOutput.cpp
@@ -43,7 +43,7 @@ bool DecOutput::DoAction(bool prev_elem_changed, LogicItemState prev_elem_state)
             SetValue(prev_val);
         }
         any_changes = true;
-        ESP_LOGD(TAG_DecOutput, ".");
+        ESP_LOGD(TAG_DecOutput, ". %u", GetValue());
     }
 
     return any_changes;

--- a/PLC_esp8266/main/LogicProgram/Outputs/IncOutput.cpp
+++ b/PLC_esp8266/main/LogicProgram/Outputs/IncOutput.cpp
@@ -37,13 +37,13 @@ bool IncOutput::DoAction(bool prev_elem_changed, LogicItemState prev_elem_state)
     if (state != prev_state) {
         if (state == LogicItemState::lisActive) {
             uint8_t prev_val = GetValue();
-            if (prev_val > LogicElement::MinValue) {
+            if (prev_val < LogicElement::MaxValue) {
                 prev_val++;
             }
             SetValue(prev_val);
         }
         any_changes = true;
-        ESP_LOGD(TAG_IncOutput, ".");
+        ESP_LOGD(TAG_IncOutput, ". %u", GetValue());
     }
 
     return any_changes;

--- a/Tests_esp8266/src/logic_ElementsBox_tests.cpp
+++ b/Tests_esp8266/src/logic_ElementsBox_tests.cpp
@@ -21,9 +21,11 @@ static uint8_t frame_buffer[DISPLAY_WIDTH * DISPLAY_HEIGHT / 8] = {};
 TEST_GROUP(LogicElementsBoxTestsGroup){ //
                                         TEST_SETUP(){ mock().disable();
 memset(frame_buffer, 0, sizeof(frame_buffer));
+Controller::Start(NULL);
 }
 
 TEST_TEARDOWN() {
+    Controller::Stop();
     mock().enable();
 }
 }
@@ -54,33 +56,37 @@ namespace {
 TEST(LogicElementsBoxTestsGroup, box_for_inputs_elements) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(9, testable.size());
-    CHECK_EQUAL(TvElementType::et_InputNO, testable[0]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_TimerSecs, testable[1]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_TimerMSecs, testable[2]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ComparatorEq, testable[3]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ComparatorGE, testable[4]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ComparatorGr, testable[5]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ComparatorLE, testable[6]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ComparatorLs, testable[7]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_Wire, testable[8]->GetElementType());
+    CHECK_EQUAL(10, testable.size());
+    CHECK_EQUAL(TvElementType::et_InputNC, testable[0]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_InputNO, testable[1]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_TimerSecs, testable[2]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_TimerMSecs, testable[3]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_ComparatorEq, testable[4]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_ComparatorGE, testable[5]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_ComparatorGr, testable[6]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_ComparatorLE, testable[7]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_ComparatorLs, testable[8]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_Wire, testable[9]->GetElementType());
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, box_for_outputs_elements) {
     IncOutput stored_element(MapIO::O1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(5, testable.size());
+    CHECK_EQUAL(6, testable.size());
     CHECK_EQUAL(TvElementType::et_DirectOutput, testable[0]->GetElementType());
     CHECK_EQUAL(TvElementType::et_SetOutput, testable[1]->GetElementType());
     CHECK_EQUAL(TvElementType::et_ResetOutput, testable[2]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_DecOutput, testable[3]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_Wire, testable[4]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_IncOutput, testable[3]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_DecOutput, testable[4]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_Wire, testable[5]->GetElementType());
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, box_for_wire) {
     Wire stored_element;
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(14, testable.size());
+    CHECK_EQUAL(15, testable.size());
     CHECK_EQUAL(TvElementType::et_InputNC, testable[0]->GetElementType());
     CHECK_EQUAL(TvElementType::et_InputNO, testable[1]->GetElementType());
     CHECK_EQUAL(TvElementType::et_TimerSecs, testable[2]->GetElementType());
@@ -95,12 +101,13 @@ TEST(LogicElementsBoxTestsGroup, box_for_wire) {
     CHECK_EQUAL(TvElementType::et_ResetOutput, testable[11]->GetElementType());
     CHECK_EQUAL(TvElementType::et_IncOutput, testable[12]->GetElementType());
     CHECK_EQUAL(TvElementType::et_DecOutput, testable[13]->GetElementType());
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, hide_output_elements) {
     Wire stored_element;
     ElementsBox testable(100, &stored_element, true);
-    CHECK_EQUAL(9, testable.size());
+    CHECK_EQUAL(10, testable.size());
     CHECK_EQUAL(TvElementType::et_InputNC, testable[0]->GetElementType());
     CHECK_EQUAL(TvElementType::et_InputNO, testable[1]->GetElementType());
     CHECK_EQUAL(TvElementType::et_TimerSecs, testable[2]->GetElementType());
@@ -110,24 +117,26 @@ TEST(LogicElementsBoxTestsGroup, hide_output_elements) {
     CHECK_EQUAL(TvElementType::et_ComparatorGr, testable[6]->GetElementType());
     CHECK_EQUAL(TvElementType::et_ComparatorLE, testable[7]->GetElementType());
     CHECK_EQUAL(TvElementType::et_ComparatorLs, testable[8]->GetElementType());
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_input_element) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(9, testable.size());
+    CHECK_EQUAL(10, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonInput = CommonInput::TryToCast(element);
         if (element_as_commonInput != NULL) {
             CHECK_EQUAL(MapIO::V1, element_as_commonInput->GetIoAdr());
         }
     }
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_comparator_element) {
     ComparatorEq stored_element(42, MapIO::AI);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(9, testable.size());
+    CHECK_EQUAL(10, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonInput = CommonInput::TryToCast(element);
         if (element_as_commonInput != NULL) {
@@ -138,13 +147,14 @@ TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_comparator_element) {
             }
         }
     }
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup,
      takes_params_from_stored_element__set_reference_to_zero_by_default_for_comparators) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(9, testable.size());
+    CHECK_EQUAL(10, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonInput = CommonInput::TryToCast(element);
         if (element_as_commonInput != NULL) {
@@ -155,12 +165,13 @@ TEST(LogicElementsBoxTestsGroup,
             }
         }
     }
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_TimerSec_element) {
     TimerSecs stored_element(42);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(9, testable.size());
+    CHECK_EQUAL(10, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonTimer = CommonTimer::TryToCast(element);
         if (element_as_commonTimer != NULL) {
@@ -170,12 +181,13 @@ TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_TimerSec_element) {
             }
         }
     }
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_TimerMSec_element) {
     TimerMSecs stored_element(42000);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(9, testable.size());
+    CHECK_EQUAL(10, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonTimer = CommonTimer::TryToCast(element);
         if (element_as_commonTimer != NULL) {
@@ -185,13 +197,14 @@ TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_TimerMSec_element) {
             }
         }
     }
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup,
      takes_params_from_stored_element__set_default_delaytime_for_timers) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(9, testable.size());
+    CHECK_EQUAL(10, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonTimer = CommonTimer::TryToCast(element);
         if (element_as_commonTimer != NULL) {
@@ -206,59 +219,86 @@ TEST(LogicElementsBoxTestsGroup,
             }
         }
     }
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_output_element) {
     IncOutput stored_element(MapIO::O1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(5, testable.size());
+    CHECK_EQUAL(6, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonOutput = CommonOutput::TryToCast(element);
         if (element_as_commonOutput != NULL) {
             CHECK_EQUAL(MapIO::O1, element_as_commonOutput->GetIoAdr());
         }
     }
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, takes_params_for_wire) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(9, testable.size());
+    CHECK_EQUAL(10, testable.size());
     for (auto *element : testable) {
         auto *element_as_wire = Wire::TryToCast(element);
         if (element_as_wire != NULL) {
             CHECK_EQUAL(24, element_as_wire->GetWidth());
         }
     }
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, no_available_space_for_timers_and_comparators) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(7, &stored_element, false);
-    CHECK_EQUAL(2, testable.size());
+    CHECK_EQUAL(3, testable.size());
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, use_GetElementType_from_selected) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(100, &stored_element, false);
     CHECK_EQUAL(TvElementType::et_InputNC, testable.GetElementType());
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, use_DoAction_from_selected) {
-    TestableComparatorEq stored_element(42, MapIO::AI);
-    ElementsBox testable(100, &stored_element, false);
-    testable.DoAction(false, LogicItemState::lisActive);
+    mock().enable();
+    volatile uint16_t adc = 42 / 0.1;
+    mock().expectNCalls(1, "vTaskDelay").ignoreOtherParameters();
+    mock().expectNCalls(1, "esp_timer_get_time").ignoreOtherParameters();
+    mock()
+        .expectNCalls(1, "adc_read")
+        .withOutputParameterReturning("adc", (const void *)&adc, sizeof(adc));
+    Controller::GetIOValues().AI.value = LogicElement::MinValue;
+    Controller::GetIOValues().AI.required = true;
+    CHECK_TRUE(Controller::SampleIOValues());
 
-    CHECK_TRUE(stored_element.DoAction_called);
+    TestableComparatorEq fake_doaction_element(42 / 0.4, MapIO::AI);
+    ElementsBox testable(100, &fake_doaction_element, false);
+    CHECK_TRUE(testable.DoAction(false, LogicItemState::lisActive));
+    CHECK_EQUAL(LogicItemState::lisActive, testable.GetSelectedElement()->GetState());
+
+    CHECK_FALSE(fake_doaction_element.DoAction_called);
+    delete testable.GetSelectedElement();
 }
 
-TEST(LogicElementsBoxTestsGroup, use_Render_from_selected) {
-    TestableComparatorEq stored_element(42, MapIO::AI);
-    ElementsBox testable(100, &stored_element, false);
-    Point start_point = {};
+TEST(LogicElementsBoxTestsGroup, Render_calls_a_function_on_the_inner_element) {
+    TestableComparatorEq fake_rendering_element(42, MapIO::AI);
+    ElementsBox testable(100, &fake_rendering_element, false);
+    Point start_point = { 0, INCOME_RAIL_TOP };
     testable.Render(frame_buffer, LogicItemState::lisActive, &start_point);
+    delete testable.GetSelectedElement();
 
-    CHECK_TRUE(stored_element.Render_called);
+    bool any_pixel_coloring = false;
+    for (size_t i = 0; i < sizeof(frame_buffer); i++) {
+        if (frame_buffer[i] != 0) {
+            any_pixel_coloring = true;
+            break;
+        }
+    }
+    CHECK_TRUE(any_pixel_coloring);
+    CHECK_EQUAL(32, start_point.x);
 }
 
 TEST(LogicElementsBoxTestsGroup, SelectNext__change__selected_index__to_backward) {
@@ -266,6 +306,14 @@ TEST(LogicElementsBoxTestsGroup, SelectNext__change__selected_index__to_backward
     ElementsBox testable(100, &stored_element, false);
     CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
     testable.SelectNext();
+    CHECK_EQUAL(TvElementType::et_TimerMSecs, testable.GetElementType());
+    testable.SelectNext();
+    CHECK_EQUAL(TvElementType::et_TimerSecs, testable.GetElementType());
+    testable.SelectNext();
+    CHECK_EQUAL(TvElementType::et_InputNO, testable.GetElementType());
+    testable.SelectNext();
+    CHECK_EQUAL(TvElementType::et_InputNC, testable.GetElementType());
+    testable.SelectNext();
     CHECK_EQUAL(TvElementType::et_Wire, testable.GetElementType());
     testable.SelectNext();
     CHECK_EQUAL(TvElementType::et_ComparatorLs, testable.GetElementType());
@@ -276,21 +324,21 @@ TEST(LogicElementsBoxTestsGroup, SelectNext__change__selected_index__to_backward
     testable.SelectNext();
     CHECK_EQUAL(TvElementType::et_ComparatorGE, testable.GetElementType());
     testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_TimerMSecs, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_TimerSecs, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_InputNO, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_InputNC, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, SelectNext_selecting_elements_in_reverse_loop) {
-    auto stored_element = new ComparatorEq(42, MapIO::AI);
-    ElementsBox testable(100, stored_element, false);
+    ComparatorEq stored_element(42, MapIO::AI);
+    ElementsBox testable(100, &stored_element, false);
     CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
+    testable.SelectNext();
+    CHECK_EQUAL(TvElementType::et_TimerMSecs, testable.GetElementType());
+    testable.SelectNext();
+    CHECK_EQUAL(TvElementType::et_TimerSecs, testable.GetElementType());
+    testable.SelectNext();
+    CHECK_EQUAL(TvElementType::et_InputNO, testable.GetElementType());
+    testable.SelectNext();
+    CHECK_EQUAL(TvElementType::et_InputNC, testable.GetElementType());
     testable.SelectNext();
     CHECK_EQUAL(TvElementType::et_Wire, testable.GetElementType());
     testable.SelectNext();
@@ -302,32 +350,13 @@ TEST(LogicElementsBoxTestsGroup, SelectNext_selecting_elements_in_reverse_loop) 
     testable.SelectNext();
     CHECK_EQUAL(TvElementType::et_ComparatorGE, testable.GetElementType());
     testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_TimerMSecs, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_TimerSecs, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_InputNO, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_InputNC, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_Wire, testable.GetElementType());
     delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, SelectPrior_selecting_elements_in_loop) {
-    auto stored_element = new ComparatorEq(42, MapIO::AI);
-    ElementsBox testable(100, stored_element, false);
+    ComparatorEq stored_element(42, MapIO::AI);
+    ElementsBox testable(100, &stored_element, false);
     CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
-    testable.SelectPrior();
-    CHECK_EQUAL(TvElementType::et_InputNC, testable.GetElementType());
-    testable.SelectPrior();
-    CHECK_EQUAL(TvElementType::et_InputNO, testable.GetElementType());
-    testable.SelectPrior();
-    CHECK_EQUAL(TvElementType::et_TimerSecs, testable.GetElementType());
-    testable.SelectPrior();
-    CHECK_EQUAL(TvElementType::et_TimerMSecs, testable.GetElementType());
     testable.SelectPrior();
     CHECK_EQUAL(TvElementType::et_ComparatorGE, testable.GetElementType());
     testable.SelectPrior();
@@ -339,9 +368,15 @@ TEST(LogicElementsBoxTestsGroup, SelectPrior_selecting_elements_in_loop) {
     testable.SelectPrior();
     CHECK_EQUAL(TvElementType::et_Wire, testable.GetElementType());
     testable.SelectPrior();
-    CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
-    testable.SelectPrior();
     CHECK_EQUAL(TvElementType::et_InputNC, testable.GetElementType());
+    testable.SelectPrior();
+    CHECK_EQUAL(TvElementType::et_InputNO, testable.GetElementType());
+    testable.SelectPrior();
+    CHECK_EQUAL(TvElementType::et_TimerSecs, testable.GetElementType());
+    testable.SelectPrior();
+    CHECK_EQUAL(TvElementType::et_TimerMSecs, testable.GetElementType());
+    testable.SelectPrior();
+
     delete testable.GetSelectedElement();
 }
 
@@ -352,36 +387,39 @@ TEST(LogicElementsBoxTestsGroup, HandleButtonSelect_first_call_switch_element_to
     CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
     testable.Change();
     CHECK_TRUE(stored_element.Editing());
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, No_memleak_if_selection_changes) {
-    auto stored_element = new ComparatorEq(42, MapIO::AI);
-    ElementsBox testable(100, stored_element, false);
+    ComparatorEq stored_element(42, MapIO::AI);
+    ElementsBox testable(100, &stored_element, false);
     CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
     testable.SelectPrior();
-    CHECK_EQUAL(TvElementType::et_InputNC, testable.GetElementType());
+    CHECK_EQUAL(TvElementType::et_ComparatorGE, testable.GetElementType());
     delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, No_memleak_if_no_selection_changes) {
-    auto stored_element = new ComparatorEq(42, MapIO::AI);
-    ElementsBox testable(100, stored_element, false);
+    ComparatorEq stored_element(42, MapIO::AI);
+    ElementsBox testable(100, &stored_element, false);
     CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
     delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, In_editing_no_memleak_if_selection_changes) {
-    auto stored_element = new ComparatorEq(42, MapIO::AI);
-    ElementsBox testable(100, stored_element, false);
+    ComparatorEq stored_element(42, MapIO::AI);
+    ElementsBox testable(100, &stored_element, false);
     CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
     testable.BeginEditing();
     testable.SelectPrior();
-    CHECK_EQUAL(TvElementType::et_InputNC, testable.GetElementType());
+    CHECK_EQUAL(TvElementType::et_ComparatorGE, testable.GetElementType());
+    delete testable.GetSelectedElement();
 }
 
 TEST(LogicElementsBoxTestsGroup, In_editing_no_memleak_if_no_selection_changes) {
-    auto stored_element = new ComparatorEq(42, MapIO::AI);
-    ElementsBox testable(100, stored_element, false);
+    ComparatorEq stored_element(42, MapIO::AI);
+    ElementsBox testable(100, &stored_element, false);
     CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
     testable.BeginEditing();
+    delete testable.GetSelectedElement();
 }

--- a/Tests_esp8266/src/logic_IncOutput_tests.cpp
+++ b/Tests_esp8266/src/logic_IncOutput_tests.cpp
@@ -75,8 +75,18 @@ TEST(LogicIncOutputTestsGroup, DoAction_change_state_to_passive__due_incoming_sw
                      "no changes are expected to be detected");
 }
 
+TEST(LogicIncOutputTestsGroup, DoAction_change_state_to_active_and_increment_value) {
+    TestableIncOutput testable;
+    testable.SetIoAdr(MapIO::V1);
+
+    CHECK_TRUE(testable.DoAction(false, LogicItemState::lisActive));
+    CHECK_EQUAL(LogicItemState::lisActive, *testable.PublicMorozov_Get_state());
+    CHECK_TRUE(Controller::SampleIOValues());
+    CHECK_EQUAL(1, Controller::GetV1RelativeValue());
+}
+
 TEST(LogicIncOutputTestsGroup,
-     DoAction_change_state_to_active__and_second_call_does_not_decrement) {
+     DoAction_change_state_to_active__and_second_call_does_not_increment) {
     TestableIncOutput testable;
     testable.SetIoAdr(MapIO::V1);
 

--- a/Tests_esp8266/src/logic_Network_tests.cpp
+++ b/Tests_esp8266/src/logic_Network_tests.cpp
@@ -376,6 +376,8 @@ TEST(LogicNetworkTestsGroup, Begin_Editing_and_replacing_selected_element_with_E
     CHECK_EQUAL(TvElementType::et_InputNC, expectedElementBox->GetElementType());
     CHECK_TRUE(expectedElementBox->Editing());
     CHECK(selectedElement != expectedElementBox);
+    auto elementBox = static_cast<ElementsBox *>(expectedElementBox);
+    delete elementBox->GetSelectedElement();
 }
 
 TEST(LogicNetworkTestsGroup, EndEditing_ElementBox_switch_selection_to_network_self) {
@@ -526,7 +528,7 @@ TEST(LogicNetworkTestsGroup, EndEditing_delete_ElementBox) {
     CHECK(selectedElement != expectedElementBox);
     auto elementBox = static_cast<ElementsBox *>(expectedElementBox);
 
-    testable.SelectPrior(); 
+    testable.SelectPrior();
     CHECK_EQUAL(TvElementType::et_InputNO, expectedElementBox->GetElementType());
 
     testable.Change();

--- a/Tests_esp8266/src/logic_Network_tests.cpp
+++ b/Tests_esp8266/src/logic_Network_tests.cpp
@@ -362,8 +362,8 @@ TEST(LogicNetworkTestsGroup, Deserialize) {
 TEST(LogicNetworkTestsGroup, Begin_Editing_and_replacing_selected_element_with_ElementBox) {
     Network testable(LogicItemState::lisActive);
 
-    testable.Append(new TestableInputNC);
-    testable.Append(new TestableComparatorEq());
+    testable.Append(new InputNC(MapIO::DI));
+    testable.Append(new ComparatorEq(1, MapIO::AI));
 
     testable.SelectNext();
 
@@ -381,8 +381,8 @@ TEST(LogicNetworkTestsGroup, Begin_Editing_and_replacing_selected_element_with_E
 TEST(LogicNetworkTestsGroup, EndEditing_ElementBox_switch_selection_to_network_self) {
     Network testable(LogicItemState::lisActive);
 
-    testable.Append(new TestableInputNC);
-    testable.Append(new TestableComparatorEq());
+    testable.Append(new InputNC(MapIO::DI));
+    testable.Append(new ComparatorEq(1, MapIO::AI));
 
     testable.SelectNext();
 
@@ -505,4 +505,34 @@ TEST(LogicNetworkTestsGroup, Wire_elements_must_be_deleted_after_editing) {
     testable.Change();
     CHECK_EQUAL(2, testable.size());
     CHECK_EQUAL(TvElementType::et_ComparatorEq, testable[0]->GetElementType());
+}
+
+TEST(LogicNetworkTestsGroup, EndEditing_delete_ElementBox) {
+    Network testable(LogicItemState::lisActive);
+
+    testable.Append(new InputNC(MapIO::DI));
+    testable.Append(new ComparatorEq(1, MapIO::AI));
+    CHECK_TRUE(testable.Render(frame_buffer, 0));
+
+    testable.SelectNext();
+
+    auto selectedElement = testable[testable.GetSelectedElement()];
+    CHECK_EQUAL(TvElementType::et_InputNC, selectedElement->GetElementType());
+
+    testable.Change();
+
+    auto expectedElementBox = testable[testable.GetSelectedElement()];
+    CHECK_EQUAL(TvElementType::et_InputNC, expectedElementBox->GetElementType());
+    CHECK(selectedElement != expectedElementBox);
+    auto elementBox = static_cast<ElementsBox *>(expectedElementBox);
+
+    testable.SelectPrior(); 
+    CHECK_EQUAL(TvElementType::et_InputNO, expectedElementBox->GetElementType());
+
+    testable.Change();
+    CHECK_TRUE(elementBox->GetSelectedElement()->Editing());
+
+    testable.Change();
+
+    CHECK_EQUAL(-1, testable.GetSelectedElement());
 }

--- a/Tests_esp8266/src/logic_Network_tests.cpp
+++ b/Tests_esp8266/src/logic_Network_tests.cpp
@@ -380,6 +380,61 @@ TEST(LogicNetworkTestsGroup, Begin_Editing_and_replacing_selected_element_with_E
     delete elementBox->GetSelectedElement();
 }
 
+TEST(LogicNetworkTestsGroup, Begin_Editing_can_hide_output_elements_in_ElementBox) {
+    Network testable(LogicItemState::lisActive);
+
+    testable.Append(new InputNC(MapIO::DI));
+    testable.Append(new DirectOutput(MapIO::O1));
+    CHECK_TRUE(testable.Render(frame_buffer, 0));
+
+    testable.SelectNext();
+
+    auto selectedElement = testable[testable.GetSelectedElement()];
+    CHECK_EQUAL(TvElementType::et_InputNC, selectedElement->GetElementType());
+
+    testable.Change();
+
+    auto expectedElementBox = testable[testable.GetSelectedElement()];
+    CHECK_EQUAL(TvElementType::et_InputNC, expectedElementBox->GetElementType());
+    CHECK_TRUE(expectedElementBox->Editing());
+    auto elementBox = static_cast<ElementsBox *>(expectedElementBox);
+    CHECK_EQUAL(10, elementBox->size());
+
+    testable.SelectNext();
+    testable.SelectNext();
+    CHECK_EQUAL(TvElementType::et_ComparatorLs, expectedElementBox->GetElementType());
+
+    delete elementBox->GetSelectedElement();
+}
+
+TEST(LogicNetworkTestsGroup,
+     Begin_Editing_not_hide_output_elements_in_ElementBox_if_selected_element_is_output) {
+    Network testable(LogicItemState::lisActive);
+
+    testable.Append(new InputNC(MapIO::DI));
+    testable.Append(new DirectOutput(MapIO::O1));
+    CHECK_TRUE(testable.Render(frame_buffer, 0));
+
+    testable.SelectNext();
+    testable.SelectNext();
+
+    auto selectedElement = testable[testable.GetSelectedElement()];
+    CHECK_EQUAL(TvElementType::et_DirectOutput, selectedElement->GetElementType());
+
+    testable.Change();
+
+    auto expectedElementBox = testable[testable.GetSelectedElement()];
+    CHECK_EQUAL(TvElementType::et_DirectOutput, expectedElementBox->GetElementType());
+    CHECK_TRUE(expectedElementBox->Editing());
+    auto elementBox = static_cast<ElementsBox *>(expectedElementBox);
+    CHECK_EQUAL(6, elementBox->size());
+
+    testable.SelectPrior();
+    CHECK_EQUAL(TvElementType::et_SetOutput, expectedElementBox->GetElementType());
+
+    delete elementBox->GetSelectedElement();
+}
+
 TEST(LogicNetworkTestsGroup, EndEditing_ElementBox_switch_selection_to_network_self) {
     Network testable(LogicItemState::lisActive);
 


### PR DESCRIPTION
### !!! MERGE AFTER https://github.com/viordash/AtsPLC/pull/19 !!!

Исправлен порядок выбора элементов в ElementBox при редактировании. Теперь он всегда одинаковый:

et_InputNC
et_InputNO
et_TimerSecs
et_TimerMSecs
et_ComparatorEq
et_ComparatorGE
et_ComparatorGr
et_ComparatorLE
et_ComparatorLs
et_DirectOutput
et_SetOutput
et_ResetOutput
et_IncOutput
et_DecOutput
et_Wire
Также есть два фикса:

[fix incorrect hiding of output elements in ElementBox](https://github.com/viordash/AtsPLC/commit/7d74d10cef283eee7e815bf220367dec6a989317)
[fix DoAction for IncOutput](https://github.com/viordash/AtsPLC/commit/5b528c378a0960dd92e565302fc5f0a251ed8b7f)