### PR TITLE
Restore UI state

### DIFF
--- a/PLC_esp8266/main/LogicProgram/Ladder.cpp
+++ b/PLC_esp8266/main/LogicProgram/Ladder.cpp
@@ -50,6 +50,6 @@ IRAM_ATTR bool Ladder::Render(uint8_t *fb) {
 }
 
 void Ladder::Append(Network *network) {
-    ESP_LOGI(TAG_Ladder, "append network: %p", network);
+    ESP_LOGD(TAG_Ladder, "append network: %p", network);
     push_back(network);
 }

--- a/PLC_esp8266/main/LogicProgram/Ladder.cpp
+++ b/PLC_esp8266/main/LogicProgram/Ladder.cpp
@@ -7,7 +7,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-Ladder::Ladder() {
+Ladder::Ladder(f_UIStateChanged cb_UI_state_changed) {
+    this->cb_UI_state_changed = cb_UI_state_changed;
     view_top_index = 0;
 }
 
@@ -52,4 +53,44 @@ IRAM_ATTR bool Ladder::Render(uint8_t *fb) {
 void Ladder::Append(Network *network) {
     ESP_LOGD(TAG_Ladder, "append network: %p", network);
     push_back(network);
+}
+
+void Ladder::SetViewTopIndex(int16_t index) {
+    ESP_LOGI(TAG_Ladder, "SetViewTopIndex, index:%d", index);
+    if (index < 0 || index + Ladder::MaxViewPortCount > size()) {
+        return;
+    }
+    view_top_index = index;
+}
+
+void Ladder::SetSelectedNetworkIndex(int16_t index) {
+
+    auto selected_network = GetSelectedNetwork();
+    auto design_state = GetDesignState(selected_network);
+
+    ESP_LOGI(TAG_Ladder,
+             "SetSelectedNetworkIndex, %u, view_top_index:%u, selected_network:%d, index:%d",
+             (unsigned)design_state,
+             (unsigned)view_top_index,
+             selected_network,
+             index);
+    if (index < 0 && index >= size()) {
+        return;
+    }
+
+    switch (design_state) {
+        case EditableElement::ElementState::des_Regular:
+            (*this)[index]->Select();
+            break;
+
+        case EditableElement::ElementState::des_Selected:
+            (*this)[selected_network]->CancelSelection();
+
+            (*this)[index]->Select();
+            break;
+
+        case EditableElement::ElementState::des_Editing: {
+            break;
+        }
+    }
 }

--- a/PLC_esp8266/main/LogicProgram/Ladder.cpp
+++ b/PLC_esp8266/main/LogicProgram/Ladder.cpp
@@ -3,12 +3,14 @@
 #include "esp_attr.h"
 #include "esp_err.h"
 #include "esp_log.h"
+extern "C" {
+#include "hotreload_service.h"
+}
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 Ladder::Ladder() {
-    view_top_index = 0;
 }
 
 Ladder::~Ladder() {
@@ -23,7 +25,6 @@ void Ladder::RemoveAll() {
         ESP_LOGD(TAG_Ladder, "delete network: %p", network);
         delete network;
     }
-    view_top_index = 0;
 }
 
 bool Ladder::DoAction() {
@@ -37,15 +38,15 @@ bool Ladder::DoAction() {
 IRAM_ATTR bool Ladder::Render(uint8_t *fb) {
     bool res = true;
 
-    for (size_t i = view_top_index; i < size(); i++) {
-        uint8_t network_number = i - view_top_index;
+    for (size_t i = hotreload->view_top_index; i < size(); i++) {
+        uint8_t network_number = i - hotreload->view_top_index;
         if (network_number >= Ladder::MaxViewPortCount) {
             break;
         }
-        res &= at(i)->Render(fb, i - view_top_index);
+        res &= at(i)->Render(fb, i - hotreload->view_top_index);
     }
 
-    ScrollBar::Render(fb, size(), Ladder::MaxViewPortCount, view_top_index);
+    ScrollBar::Render(fb, size(), Ladder::MaxViewPortCount, hotreload->view_top_index);
     return res;
 }
 

--- a/PLC_esp8266/main/LogicProgram/Ladder.cpp
+++ b/PLC_esp8266/main/LogicProgram/Ladder.cpp
@@ -3,14 +3,12 @@
 #include "esp_attr.h"
 #include "esp_err.h"
 #include "esp_log.h"
-extern "C" {
-#include "hotreload_service.h"
-}
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 Ladder::Ladder() {
+    view_top_index = 0;
 }
 
 Ladder::~Ladder() {
@@ -25,6 +23,7 @@ void Ladder::RemoveAll() {
         ESP_LOGD(TAG_Ladder, "delete network: %p", network);
         delete network;
     }
+    view_top_index = 0;
 }
 
 bool Ladder::DoAction() {
@@ -38,15 +37,15 @@ bool Ladder::DoAction() {
 IRAM_ATTR bool Ladder::Render(uint8_t *fb) {
     bool res = true;
 
-    for (size_t i = hotreload->view_top_index; i < size(); i++) {
-        uint8_t network_number = i - hotreload->view_top_index;
+    for (size_t i = view_top_index; i < size(); i++) {
+        uint8_t network_number = i - view_top_index;
         if (network_number >= Ladder::MaxViewPortCount) {
             break;
         }
-        res &= at(i)->Render(fb, i - hotreload->view_top_index);
+        res &= at(i)->Render(fb, i - view_top_index);
     }
 
-    ScrollBar::Render(fb, size(), Ladder::MaxViewPortCount, hotreload->view_top_index);
+    ScrollBar::Render(fb, size(), Ladder::MaxViewPortCount, view_top_index);
     return res;
 }
 

--- a/PLC_esp8266/main/LogicProgram/Ladder.cpp
+++ b/PLC_esp8266/main/LogicProgram/Ladder.cpp
@@ -64,7 +64,6 @@ void Ladder::SetViewTopIndex(int16_t index) {
 }
 
 void Ladder::SetSelectedNetworkIndex(int16_t index) {
-
     auto selected_network = GetSelectedNetwork();
     auto design_state = GetDesignState(selected_network);
 
@@ -74,7 +73,7 @@ void Ladder::SetSelectedNetworkIndex(int16_t index) {
              (unsigned)view_top_index,
              selected_network,
              index);
-    if (index < 0 && index >= size()) {
+    if (index < 0 || index >= (int)size()) {
         return;
     }
 

--- a/PLC_esp8266/main/LogicProgram/Ladder.h
+++ b/PLC_esp8266/main/LogicProgram/Ladder.h
@@ -14,6 +14,8 @@
 
 class Ladder : public std::vector<Network *> {
   protected:
+    int view_top_index;
+
     void InitialLoad();
 
     size_t Deserialize(uint8_t *buffer, size_t buffer_size);

--- a/PLC_esp8266/main/LogicProgram/Ladder.h
+++ b/PLC_esp8266/main/LogicProgram/Ladder.h
@@ -14,8 +14,6 @@
 
 class Ladder : public std::vector<Network *> {
   protected:
-    int view_top_index;
-
     void InitialLoad();
 
     size_t Deserialize(uint8_t *buffer, size_t buffer_size);

--- a/PLC_esp8266/main/LogicProgram/Ladder.h
+++ b/PLC_esp8266/main/LogicProgram/Ladder.h
@@ -10,11 +10,15 @@
 
 #define TAG_Ladder "Ladder"
 
+typedef void (*f_UIStateChanged)(int16_t view_top_index, int16_t selected_network);
+
 #define LADDER_VERSION ((uint32_t)0x20240905)
 
 class Ladder : public std::vector<Network *> {
   protected:
-    int view_top_index;
+    int16_t view_top_index;
+
+    f_UIStateChanged cb_UI_state_changed;
 
     void InitialLoad();
 
@@ -32,7 +36,7 @@ class Ladder : public std::vector<Network *> {
     const size_t MaxNetworksCount = 42;
     const size_t MaxViewPortCount = 2;
 
-    Ladder();
+    explicit Ladder(f_UIStateChanged cb_UI_state_changed);
     ~Ladder();
 
     bool DoAction();
@@ -51,4 +55,7 @@ class Ladder : public std::vector<Network *> {
 
     void Load();
     void Store();
+
+    void SetViewTopIndex(int16_t index);
+    void SetSelectedNetworkIndex(int16_t index);
 };

--- a/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
+++ b/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
@@ -57,6 +57,7 @@ void Ladder::HandleButtonUp() {
         case EditableElement::ElementState::des_Regular:
             if (view_top_index > 0) {
                 view_top_index--;
+                cb_UI_state_changed(view_top_index, selected_network);
             }
             break;
 
@@ -66,9 +67,11 @@ void Ladder::HandleButtonUp() {
 
             if (selected_network > view_top_index) {
                 selected_network--;
+                cb_UI_state_changed(view_top_index, selected_network);
             } else if (view_top_index > 0) {
                 view_top_index--;
                 selected_network--;
+                cb_UI_state_changed(view_top_index, selected_network);
             }
             if (size() > 0) {
                 (*this)[selected_network]->Select();
@@ -115,6 +118,7 @@ void Ladder::HandleButtonDown() {
         case EditableElement::ElementState::des_Regular:
             if (view_top_index + Ladder::MaxViewPortCount < size()) {
                 view_top_index++;
+                cb_UI_state_changed(view_top_index, selected_network);
             }
             break;
 
@@ -124,9 +128,11 @@ void Ladder::HandleButtonDown() {
             if (!RemoveNetworkIfEmpty(selected_network)) {
                 if (selected_network == view_top_index) {
                     selected_network++;
+                    cb_UI_state_changed(view_top_index, selected_network);
                 } else if (view_top_index + Ladder::MaxViewPortCount <= size()) {
                     view_top_index++;
                     selected_network++;
+                    cb_UI_state_changed(view_top_index, selected_network);
                 }
             }
 
@@ -183,10 +189,13 @@ void Ladder::HandleButtonSelect() {
                 Append(new_network);
             }
             (*this)[view_top_index]->Select();
+
+            cb_UI_state_changed(view_top_index, view_top_index);
             break;
 
         case EditableElement::ElementState::des_Selected:
             (*this)[selected_network]->BeginEditing();
+            cb_UI_state_changed(view_top_index, selected_network);
             break;
 
         case EditableElement::ElementState::des_Editing:
@@ -194,6 +203,7 @@ void Ladder::HandleButtonSelect() {
             if (!(*this)[selected_network]->Editing()) {
                 RemoveNetworkIfEmpty(selected_network);
                 Store();
+                cb_UI_state_changed(view_top_index, -1);
             }
             return;
 

--- a/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
+++ b/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
@@ -3,21 +3,17 @@
 #include "esp_attr.h"
 #include "esp_err.h"
 #include "esp_log.h"
-extern "C" {
-#include "hotreload_service.h"
-}
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 bool Ladder::CanScrollAuto() {
-    return (size_t)hotreload->view_top_index == size() - Ladder::MaxViewPortCount;
+    return (size_t)view_top_index == size() - Ladder::MaxViewPortCount;
 }
 
 void Ladder::AutoScroll() {
     if (size() > Ladder::MaxViewPortCount) {
-        hotreload->view_top_index = size() - Ladder::MaxViewPortCount;
-        store_hotreload();
+        view_top_index = size() - Ladder::MaxViewPortCount;
     }
 }
 
@@ -54,14 +50,13 @@ void Ladder::HandleButtonUp() {
     ESP_LOGD(TAG_Ladder,
              "HandleButtonUp, %u, view_top_index:%u, selected_network:%d",
              (unsigned)design_state,
-             hotreload->view_top_index,
+             view_top_index,
              selected_network);
 
     switch (design_state) {
         case EditableElement::ElementState::des_Regular:
-            if (hotreload->view_top_index > 0) {
-                hotreload->view_top_index--;
-                store_hotreload();
+            if (view_top_index > 0) {
+                view_top_index--;
             }
             break;
 
@@ -69,11 +64,10 @@ void Ladder::HandleButtonUp() {
             (*this)[selected_network]->CancelSelection();
             RemoveNetworkIfEmpty(selected_network);
 
-            if (selected_network > hotreload->view_top_index) {
+            if (selected_network > view_top_index) {
                 selected_network--;
-            } else if (hotreload->view_top_index > 0) {
-                hotreload->view_top_index--;
-                store_hotreload();
+            } else if (view_top_index > 0) {
+                view_top_index--;
                 selected_network--;
             }
             if (size() > 0) {
@@ -94,7 +88,7 @@ void Ladder::HandleButtonPageUp() {
     ESP_LOGI(TAG_Ladder,
              "HandleButtonPageUp, %u, view_top_index:%u, selected_network:%d",
              (unsigned)design_state,
-             hotreload->view_top_index,
+             view_top_index,
              selected_network);
 
     switch (design_state) {
@@ -114,14 +108,13 @@ void Ladder::HandleButtonDown() {
     ESP_LOGD(TAG_Ladder,
              "HandleButtonDown, %u, view_top_index:%u, selected_network:%d",
              (unsigned)design_state,
-             hotreload->view_top_index,
+             view_top_index,
              selected_network);
 
     switch (design_state) {
         case EditableElement::ElementState::des_Regular:
-            if (hotreload->view_top_index + Ladder::MaxViewPortCount < size()) {
-                hotreload->view_top_index++;
-                store_hotreload();
+            if (view_top_index + Ladder::MaxViewPortCount < size()) {
+                view_top_index++;
             }
             break;
 
@@ -129,11 +122,10 @@ void Ladder::HandleButtonDown() {
             (*this)[selected_network]->CancelSelection();
 
             if (!RemoveNetworkIfEmpty(selected_network)) {
-                if (selected_network == hotreload->view_top_index) {
+                if (selected_network == view_top_index) {
                     selected_network++;
-                } else if (hotreload->view_top_index + Ladder::MaxViewPortCount <= size()) {
-                    hotreload->view_top_index++;
-                    store_hotreload();
+                } else if (view_top_index + Ladder::MaxViewPortCount <= size()) {
+                    view_top_index++;
                     selected_network++;
                 }
             }
@@ -161,7 +153,7 @@ void Ladder::HandleButtonPageDown() {
     ESP_LOGI(TAG_Ladder,
              "HandleButtonPageDown, %u, view_top_index:%u, selected_network:%d",
              (unsigned)design_state,
-             hotreload->view_top_index,
+             view_top_index,
              selected_network);
 
     switch (design_state) {
@@ -181,7 +173,7 @@ void Ladder::HandleButtonSelect() {
     ESP_LOGD(TAG_Ladder,
              "HandleButtonSelect, %u, view_top_index:%u, selected_network:%d",
              (unsigned)design_state,
-             (unsigned)hotreload->view_top_index,
+             (unsigned)view_top_index,
              selected_network);
 
     switch (design_state) {
@@ -190,7 +182,7 @@ void Ladder::HandleButtonSelect() {
                 auto new_network = new Network(LogicItemState::lisActive);
                 Append(new_network);
             }
-            (*this)[hotreload->view_top_index]->Select();
+            (*this)[view_top_index]->Select();
             break;
 
         case EditableElement::ElementState::des_Selected:

--- a/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
+++ b/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
@@ -3,17 +3,21 @@
 #include "esp_attr.h"
 #include "esp_err.h"
 #include "esp_log.h"
+extern "C" {
+#include "hotreload_service.h"
+}
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 bool Ladder::CanScrollAuto() {
-    return (size_t)view_top_index == size() - Ladder::MaxViewPortCount;
+    return (size_t)hotreload->view_top_index == size() - Ladder::MaxViewPortCount;
 }
 
 void Ladder::AutoScroll() {
     if (size() > Ladder::MaxViewPortCount) {
-        view_top_index = size() - Ladder::MaxViewPortCount;
+        hotreload->view_top_index = size() - Ladder::MaxViewPortCount;
+        store_hotreload();
     }
 }
 
@@ -50,13 +54,14 @@ void Ladder::HandleButtonUp() {
     ESP_LOGD(TAG_Ladder,
              "HandleButtonUp, %u, view_top_index:%u, selected_network:%d",
              (unsigned)design_state,
-             view_top_index,
+             hotreload->view_top_index,
              selected_network);
 
     switch (design_state) {
         case EditableElement::ElementState::des_Regular:
-            if (view_top_index > 0) {
-                view_top_index--;
+            if (hotreload->view_top_index > 0) {
+                hotreload->view_top_index--;
+                store_hotreload();
             }
             break;
 
@@ -64,10 +69,11 @@ void Ladder::HandleButtonUp() {
             (*this)[selected_network]->CancelSelection();
             RemoveNetworkIfEmpty(selected_network);
 
-            if (selected_network > view_top_index) {
+            if (selected_network > hotreload->view_top_index) {
                 selected_network--;
-            } else if (view_top_index > 0) {
-                view_top_index--;
+            } else if (hotreload->view_top_index > 0) {
+                hotreload->view_top_index--;
+                store_hotreload();
                 selected_network--;
             }
             if (size() > 0) {
@@ -88,7 +94,7 @@ void Ladder::HandleButtonPageUp() {
     ESP_LOGI(TAG_Ladder,
              "HandleButtonPageUp, %u, view_top_index:%u, selected_network:%d",
              (unsigned)design_state,
-             view_top_index,
+             hotreload->view_top_index,
              selected_network);
 
     switch (design_state) {
@@ -108,13 +114,14 @@ void Ladder::HandleButtonDown() {
     ESP_LOGD(TAG_Ladder,
              "HandleButtonDown, %u, view_top_index:%u, selected_network:%d",
              (unsigned)design_state,
-             view_top_index,
+             hotreload->view_top_index,
              selected_network);
 
     switch (design_state) {
         case EditableElement::ElementState::des_Regular:
-            if (view_top_index + Ladder::MaxViewPortCount < size()) {
-                view_top_index++;
+            if (hotreload->view_top_index + Ladder::MaxViewPortCount < size()) {
+                hotreload->view_top_index++;
+                store_hotreload();
             }
             break;
 
@@ -122,10 +129,11 @@ void Ladder::HandleButtonDown() {
             (*this)[selected_network]->CancelSelection();
 
             if (!RemoveNetworkIfEmpty(selected_network)) {
-                if (selected_network == view_top_index) {
+                if (selected_network == hotreload->view_top_index) {
                     selected_network++;
-                } else if (view_top_index + Ladder::MaxViewPortCount <= size()) {
-                    view_top_index++;
+                } else if (hotreload->view_top_index + Ladder::MaxViewPortCount <= size()) {
+                    hotreload->view_top_index++;
+                    store_hotreload();
                     selected_network++;
                 }
             }
@@ -153,7 +161,7 @@ void Ladder::HandleButtonPageDown() {
     ESP_LOGI(TAG_Ladder,
              "HandleButtonPageDown, %u, view_top_index:%u, selected_network:%d",
              (unsigned)design_state,
-             view_top_index,
+             hotreload->view_top_index,
              selected_network);
 
     switch (design_state) {
@@ -173,7 +181,7 @@ void Ladder::HandleButtonSelect() {
     ESP_LOGD(TAG_Ladder,
              "HandleButtonSelect, %u, view_top_index:%u, selected_network:%d",
              (unsigned)design_state,
-             (unsigned)view_top_index,
+             (unsigned)hotreload->view_top_index,
              selected_network);
 
     switch (design_state) {
@@ -182,7 +190,7 @@ void Ladder::HandleButtonSelect() {
                 auto new_network = new Network(LogicItemState::lisActive);
                 Append(new_network);
             }
-            (*this)[view_top_index]->Select();
+            (*this)[hotreload->view_top_index]->Select();
             break;
 
         case EditableElement::ElementState::des_Selected:

--- a/PLC_esp8266/main/LogicProgram/Network.cpp
+++ b/PLC_esp8266/main/LogicProgram/Network.cpp
@@ -128,7 +128,7 @@ IRAM_ATTR bool Network::Render(uint8_t *fb, uint8_t network_number) {
 }
 
 void Network::Append(LogicElement *element) {
-    ESP_LOGI(TAG_Network, "append elem: %p", element);
+    ESP_LOGD(TAG_Network, "append elem: %p", element);
     push_back(element);
 }
 
@@ -302,7 +302,8 @@ void Network::Change() {
 
     if ((*this)[selected_element]->Selected()) {
         auto source_element = (*this)[selected_element];
-        bool hide_output_elements = HasOutputElement() && CommonOutput::TryToCast(source_element) == NULL;
+        bool hide_output_elements =
+            HasOutputElement() && CommonOutput::TryToCast(source_element) == NULL;
         ESP_LOGI(TAG_Network, "hide_output_elements:%u", hide_output_elements);
         auto elementBox = new ElementsBox(fill_wire, source_element, hide_output_elements);
         elementBox->BeginEditing();

--- a/PLC_esp8266/main/hotreload_service.c
+++ b/PLC_esp8266/main/hotreload_service.c
@@ -26,6 +26,7 @@ void init_hotreload() {
     hotreload->is_hotstart = false;
     hotreload->restart_count = 0;
     hotreload->view_top_index = 0;
+    hotreload->selected_network = -1;
 }
 
 void load_hotreload() {

--- a/PLC_esp8266/main/hotreload_service.c
+++ b/PLC_esp8266/main/hotreload_service.c
@@ -25,6 +25,7 @@ hotreload_data *hotreload = NULL;
 void init_hotreload() {
     hotreload->is_hotstart = false;
     hotreload->restart_count = 0;
+    hotreload->view_top_index = 0;
 }
 
 void load_hotreload() {

--- a/PLC_esp8266/main/hotreload_service.c
+++ b/PLC_esp8266/main/hotreload_service.c
@@ -2,6 +2,7 @@
 #include "crc32.h"
 #include "esp8266/eagle_soc.h"
 #include "esp_log.h"
+#include <stdbool.h>
 #include <string.h>
 
 static const char *TAG_hotreload = "hotreload";
@@ -21,6 +22,11 @@ typedef struct {
 
 volatile rtc_hotreload_data *_rtc_hotreload_data = (volatile rtc_hotreload_data *)RTC_USER_BASE;
 hotreload_data *hotreload = NULL;
+
+_Static_assert(sizeof(hotreload->is_hotstart) == 4, "sizeof(is_hotstart)");
+_Static_assert(sizeof(hotreload->restart_count) == 4, "sizeof(restart_count)");
+_Static_assert(sizeof(hotreload->view_top_index) == 4, "sizeof(view_top_index)");
+_Static_assert(sizeof(hotreload->selected_network) == 4, "sizeof(selected_network)");
 
 void init_hotreload() {
     hotreload->is_hotstart = false;

--- a/PLC_esp8266/main/hotreload_service.h
+++ b/PLC_esp8266/main/hotreload_service.h
@@ -7,6 +7,7 @@
 typedef struct {
     bool is_hotstart;
     uint32_t restart_count;
+    int16_t view_top_index;
 } hotreload_data;
 
 extern hotreload_data *hotreload;

--- a/PLC_esp8266/main/hotreload_service.h
+++ b/PLC_esp8266/main/hotreload_service.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <stdbool.h>
 #include <stdint.h>
 #include <unistd.h>
 
 typedef struct {
-    bool is_hotstart;
+    int32_t is_hotstart;
     uint32_t restart_count;
-    int16_t view_top_index;
-    int16_t selected_network;
+    int32_t view_top_index;
+    int32_t selected_network;
 } hotreload_data;
 
 extern hotreload_data *hotreload;

--- a/PLC_esp8266/main/hotreload_service.h
+++ b/PLC_esp8266/main/hotreload_service.h
@@ -8,6 +8,7 @@ typedef struct {
     bool is_hotstart;
     uint32_t restart_count;
     int16_t view_top_index;
+    int16_t selected_network;
 } hotreload_data;
 
 extern hotreload_data *hotreload;

--- a/Tests_esp8266/src/hotreload_tests.c
+++ b/Tests_esp8266/src/hotreload_tests.c
@@ -24,12 +24,14 @@ TEST_C(HotReloadTestsGroup, load_store) {
 
     hotreload->is_hotstart = true;
     hotreload->restart_count = 19;
+    hotreload->view_top_index = 75;
 
     store_hotreload();
 
     CHECK_EQUAL_C_UINT(0xDE4572BB, testable->magic);
     CHECK_EQUAL_C_BOOL(true, testable->data.is_hotstart);
     CHECK_EQUAL_C_UINT(19, testable->data.restart_count);
+    CHECK_EQUAL_C_UINT(75, testable->data.view_top_index);
 }
 
 TEST_C(HotReloadTestsGroup, load_if_memory_cleared) {
@@ -41,4 +43,5 @@ TEST_C(HotReloadTestsGroup, load_if_memory_cleared) {
     CHECK_EQUAL_C_UINT(0, testable->magic);
     CHECK_EQUAL_C_BOOL(false, testable->data.is_hotstart);
     CHECK_EQUAL_C_UINT(0, testable->data.restart_count);
+    CHECK_EQUAL_C_UINT(0, testable->data.view_top_index);
 }

--- a/Tests_esp8266/src/hotreload_tests.c
+++ b/Tests_esp8266/src/hotreload_tests.c
@@ -25,6 +25,7 @@ TEST_C(HotReloadTestsGroup, load_store) {
     hotreload->is_hotstart = true;
     hotreload->restart_count = 19;
     hotreload->view_top_index = 75;
+    hotreload->selected_network = 7;
 
     store_hotreload();
 
@@ -32,6 +33,7 @@ TEST_C(HotReloadTestsGroup, load_store) {
     CHECK_EQUAL_C_BOOL(true, testable->data.is_hotstart);
     CHECK_EQUAL_C_UINT(19, testable->data.restart_count);
     CHECK_EQUAL_C_UINT(75, testable->data.view_top_index);
+    CHECK_EQUAL_C_UINT(7, testable->data.selected_network);
 }
 
 TEST_C(HotReloadTestsGroup, load_if_memory_cleared) {
@@ -44,4 +46,5 @@ TEST_C(HotReloadTestsGroup, load_if_memory_cleared) {
     CHECK_EQUAL_C_BOOL(false, testable->data.is_hotstart);
     CHECK_EQUAL_C_UINT(0, testable->data.restart_count);
     CHECK_EQUAL_C_UINT(0, testable->data.view_top_index);
+    CHECK_EQUAL_C_UINT(-1, testable->data.selected_network);
 }

--- a/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
+++ b/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
@@ -42,7 +42,19 @@ namespace {
 
     class TestableLadder : public Ladder {
       public:
-        int *PublicMorozov_Get_view_top_index() {
+        static int16_t hotreload_view_top_index;
+        static int16_t hotreload_selected_network;
+
+        TestableLadder()
+            : Ladder([](int16_t view_top_index, int16_t selected_network) {
+                  TestableLadder::hotreload_view_top_index = view_top_index;
+                  TestableLadder::hotreload_selected_network = selected_network;
+              }) {
+            TestableLadder::hotreload_view_top_index = 0;
+            TestableLadder::hotreload_selected_network = 0;
+        }
+
+        int16_t *PublicMorozov_Get_view_top_index() {
             return &view_top_index;
         }
         int PublicMorozov_GetSelectedNetwork() {
@@ -55,6 +67,10 @@ namespace {
             return RemoveNetworkIfEmpty(network_id);
         }
     };
+
+    int16_t TestableLadder::hotreload_view_top_index = 0;
+    int16_t TestableLadder::hotreload_selected_network = 0;
+
     class TestableNetwork : public Network {
       public:
         TestableNetwork(LogicItemState state) : Network(state) {
@@ -347,7 +363,7 @@ TEST(LogicLadderDesignerTestsGroup, HandleButtonSelect_calls_store_after_network
 
     testable.HandleButtonSelect();
 
-    Ladder ladder_load;
+    Ladder ladder_load([](int16_t, int16_t) {});
     ladder_load.Load();
 
     CHECK_EQUAL(1, ladder_load.size());

--- a/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
+++ b/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
@@ -374,3 +374,96 @@ TEST(LogicLadderDesignerTestsGroup, HandleButtonSelect_calls_store_after_network
     CHECK_EQUAL(TvElementType::et_DirectOutput, (*network_load)[1]->GetElementType());
     CHECK_EQUAL(MapIO::O1, ((DirectOutput *)(*network_load)[1])->GetIoAdr());
 }
+
+TEST(LogicLadderDesignerTestsGroup, SetViewTopIndex_do_nothing_when_incorrect_index) {
+    TestableLadder testable;
+    testable.Append(new Network(LogicItemState::lisActive));
+    testable.Append(new Network(LogicItemState::lisActive));
+    testable.Append(new Network(LogicItemState::lisActive));
+    testable.Append(new Network(LogicItemState::lisActive));
+
+    testable.SetViewTopIndex(-1);
+    CHECK_EQUAL(0, *testable.PublicMorozov_Get_view_top_index());
+
+    testable.SetViewTopIndex(3);
+    CHECK_EQUAL(0, *testable.PublicMorozov_Get_view_top_index());
+
+    testable.SetViewTopIndex(4);
+    CHECK_EQUAL(0, *testable.PublicMorozov_Get_view_top_index());
+}
+
+TEST(LogicLadderDesignerTestsGroup, SetViewTopIndex) {
+    TestableLadder testable;
+    testable.Append(new Network(LogicItemState::lisActive));
+    testable.Append(new Network(LogicItemState::lisActive));
+    testable.Append(new Network(LogicItemState::lisActive));
+    testable.Append(new Network(LogicItemState::lisActive));
+
+    testable.SetViewTopIndex(0);
+    CHECK_EQUAL(0, *testable.PublicMorozov_Get_view_top_index());
+
+    testable.SetViewTopIndex(1);
+    CHECK_EQUAL(1, *testable.PublicMorozov_Get_view_top_index());
+
+    testable.SetViewTopIndex(2);
+    CHECK_EQUAL(2, *testable.PublicMorozov_Get_view_top_index());
+}
+
+TEST(LogicLadderDesignerTestsGroup, SetSelectedNetworkIndex_do_nothing_when_incorrect_index) {
+    TestableLadder testable;
+    testable.Append(new Network(LogicItemState::lisActive));
+    testable.Append(new Network(LogicItemState::lisActive));
+    auto selected_network = new Network();
+    testable.Append(selected_network);
+    selected_network->Select();
+    testable.Append(new Network(LogicItemState::lisActive));
+
+    testable.SetSelectedNetworkIndex(-1);
+    CHECK_EQUAL(2, testable.PublicMorozov_GetSelectedNetwork());
+
+    testable.SetSelectedNetworkIndex(5);
+    CHECK_EQUAL(2, testable.PublicMorozov_GetSelectedNetwork());
+}
+
+TEST(LogicLadderDesignerTestsGroup, SetSelectedNetworkIndex_when_no_preselected) {
+    TestableLadder testable;
+    auto network0 = new Network(LogicItemState::lisActive);
+    auto network1 = new Network(LogicItemState::lisActive);
+    auto network2 = new Network(LogicItemState::lisActive);
+    auto network3 = new Network(LogicItemState::lisActive);
+    testable.Append(network0);
+    testable.Append(network1);
+    testable.Append(network2);
+    testable.Append(network3);
+
+    testable.SetSelectedNetworkIndex(1);
+    CHECK_EQUAL(1, testable.PublicMorozov_GetSelectedNetwork());
+    CHECK_TRUE(network1->Selected());
+
+    testable.SetSelectedNetworkIndex(3);
+    CHECK_EQUAL(3, testable.PublicMorozov_GetSelectedNetwork());
+    CHECK_FALSE(network1->Selected());
+    CHECK_TRUE(network3->Selected());
+}
+
+TEST(LogicLadderDesignerTestsGroup, SetSelectedNetworkIndex_if_network_is_editing_then_do_nothing) {
+    TestableLadder testable;
+    auto network0 = new Network(LogicItemState::lisActive);
+    auto network1 = new Network(LogicItemState::lisActive);
+    auto network2 = new Network(LogicItemState::lisActive);
+    auto network3 = new Network(LogicItemState::lisActive);
+    testable.Append(network0);
+    testable.Append(network1);
+    testable.Append(network2);
+    testable.Append(network3);
+
+    testable.SetSelectedNetworkIndex(1);
+    CHECK_EQUAL(1, testable.PublicMorozov_GetSelectedNetwork());
+    CHECK_TRUE(network1->Selected());
+    network1->BeginEditing();
+
+    testable.SetSelectedNetworkIndex(3);
+    CHECK_EQUAL(1, testable.PublicMorozov_GetSelectedNetwork());
+    CHECK_TRUE(network1->Editing());
+    CHECK_FALSE(network3->Selected());
+}

--- a/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
+++ b/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
@@ -50,8 +50,8 @@ namespace {
                   TestableLadder::hotreload_view_top_index = view_top_index;
                   TestableLadder::hotreload_selected_network = selected_network;
               }) {
-            TestableLadder::hotreload_view_top_index = 0;
-            TestableLadder::hotreload_selected_network = 0;
+            TestableLadder::hotreload_view_top_index = -19;
+            TestableLadder::hotreload_selected_network = -19;
         }
 
         int16_t *PublicMorozov_Get_view_top_index() {
@@ -466,4 +466,112 @@ TEST(LogicLadderDesignerTestsGroup, SetSelectedNetworkIndex_if_network_is_editin
     CHECK_EQUAL(1, testable.PublicMorozov_GetSelectedNetwork());
     CHECK_TRUE(network1->Editing());
     CHECK_FALSE(network3->Selected());
+}
+
+TEST(LogicLadderDesignerTestsGroup, HandleButtonUp_calls__cb_UI_state_changed__when_scrolling) {
+    TestableLadder testable;
+    auto network0 = new Network(LogicItemState::lisActive);
+    auto network1 = new Network(LogicItemState::lisActive);
+    auto network2 = new Network(LogicItemState::lisActive);
+    auto network3 = new Network(LogicItemState::lisActive);
+    network0->Append(new InputNC(MapIO::DI));
+    network1->Append(new InputNC(MapIO::DI));
+    network2->Append(new InputNC(MapIO::DI));
+    network3->Append(new InputNC(MapIO::DI));
+    testable.Append(network0);
+    testable.Append(network1);
+    testable.Append(network2);
+    testable.Append(network3);
+
+    *testable.PublicMorozov_Get_view_top_index() = 2;
+
+    testable.HandleButtonUp();
+    CHECK_EQUAL(1, *testable.PublicMorozov_Get_view_top_index());
+    CHECK_EQUAL(1, TestableLadder::hotreload_view_top_index);
+    CHECK_EQUAL(-1, TestableLadder::hotreload_selected_network);
+
+    *testable.PublicMorozov_Get_view_top_index() = 3;
+    network3->Select();
+
+    testable.HandleButtonUp();
+    CHECK_EQUAL(2, *testable.PublicMorozov_Get_view_top_index());
+    CHECK_EQUAL(2, TestableLadder::hotreload_view_top_index);
+    CHECK_EQUAL(2, TestableLadder::hotreload_selected_network);
+
+    testable.HandleButtonUp();
+    CHECK_EQUAL(1, *testable.PublicMorozov_Get_view_top_index());
+    CHECK_EQUAL(1, TestableLadder::hotreload_view_top_index);
+    CHECK_EQUAL(1, TestableLadder::hotreload_selected_network);
+}
+
+TEST(LogicLadderDesignerTestsGroup, HandleButtonDown_calls__cb_UI_state_changed__when_scrolling) {
+    TestableLadder testable;
+    auto network0 = new Network(LogicItemState::lisActive);
+    auto network1 = new Network(LogicItemState::lisActive);
+    auto network2 = new Network(LogicItemState::lisActive);
+    auto network3 = new Network(LogicItemState::lisActive);
+    network0->Append(new InputNC(MapIO::DI));
+    network1->Append(new InputNC(MapIO::DI));
+    network2->Append(new InputNC(MapIO::DI));
+    network3->Append(new InputNC(MapIO::DI));
+    testable.Append(network0);
+    testable.Append(network1);
+    testable.Append(network2);
+    testable.Append(network3);
+
+    *testable.PublicMorozov_Get_view_top_index() = 1;
+
+    testable.HandleButtonDown();
+    CHECK_EQUAL(2, *testable.PublicMorozov_Get_view_top_index());
+    CHECK_EQUAL(2, TestableLadder::hotreload_view_top_index);
+    CHECK_EQUAL(-1, TestableLadder::hotreload_selected_network);
+
+    *testable.PublicMorozov_Get_view_top_index() = 0;
+    network0->Select();
+
+    testable.HandleButtonDown();
+    CHECK_EQUAL(0, *testable.PublicMorozov_Get_view_top_index());
+    CHECK_EQUAL(0, TestableLadder::hotreload_view_top_index);
+    CHECK_EQUAL(1, TestableLadder::hotreload_selected_network);
+
+    testable.HandleButtonDown();
+    CHECK_EQUAL(1, *testable.PublicMorozov_Get_view_top_index());
+    CHECK_EQUAL(1, TestableLadder::hotreload_view_top_index);
+    CHECK_EQUAL(2, TestableLadder::hotreload_selected_network);
+}
+
+TEST(LogicLadderDesignerTestsGroup, HandleButtonSelect_calls__cb_UI_state_changed) {
+    TestableLadder testable;
+
+    auto network0 = new Network(LogicItemState::lisActive);
+    network0->Append(new InputNC(MapIO::DI));
+    testable.Append(network0);
+    testable.Append(new Network(LogicItemState::lisActive));
+
+    testable.HandleButtonSelect();
+    CHECK_EQUAL(0, testable.PublicMorozov_GetSelectedNetwork());
+    CHECK_EQUAL(0, TestableLadder::hotreload_view_top_index);
+    CHECK_EQUAL(0, TestableLadder::hotreload_selected_network);
+    CHECK_TRUE(testable[0]->Selected());
+
+    TestableLadder::hotreload_view_top_index = -1;
+    TestableLadder::hotreload_selected_network = -1;
+
+    testable.HandleButtonSelect();
+    CHECK_EQUAL(0, testable.PublicMorozov_GetSelectedNetwork());
+    CHECK_EQUAL(0, TestableLadder::hotreload_view_top_index);
+    CHECK_EQUAL(0, TestableLadder::hotreload_selected_network);
+    CHECK_TRUE(testable[0]->Editing());
+
+    TestableLadder::hotreload_view_top_index = -1;
+    TestableLadder::hotreload_selected_network = -1;
+
+    testable.HandleButtonSelect();
+    CHECK_EQUAL(-1, testable.PublicMorozov_GetSelectedNetwork());
+    CHECK_EQUAL(0, TestableLadder::hotreload_view_top_index);
+    CHECK_EQUAL(-1, TestableLadder::hotreload_selected_network);
+    CHECK_FALSE(testable[0]->Editing());
+    CHECK_FALSE(testable[0]->Selected());
+
+
 }

--- a/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
+++ b/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
@@ -11,6 +11,9 @@
 
 #include "main/LogicProgram/LogicProgram.h"
 #include "main/redundant_storage.h"
+extern "C" {
+#include "main/hotreload_service.h"
+}
 
 #include "tests_utils.h"
 
@@ -21,6 +24,7 @@ TEST_GROUP(LogicLadderDesignerTestsGroup){ //
 memset(frame_buffer, 0, sizeof(frame_buffer));
 create_storage_0();
 create_storage_1();
+hotreload->view_top_index = 0;
 }
 
 TEST_TEARDOWN() {
@@ -42,8 +46,8 @@ namespace {
 
     class TestableLadder : public Ladder {
       public:
-        int *PublicMorozov_Get_view_top_index() {
-            return &view_top_index;
+        int16_t *PublicMorozov_Get_view_top_index() {
+            return &hotreload->view_top_index;
         }
         int PublicMorozov_GetSelectedNetwork() {
             return GetSelectedNetwork();

--- a/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
+++ b/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
@@ -11,9 +11,6 @@
 
 #include "main/LogicProgram/LogicProgram.h"
 #include "main/redundant_storage.h"
-extern "C" {
-#include "main/hotreload_service.h"
-}
 
 #include "tests_utils.h"
 
@@ -24,7 +21,6 @@ TEST_GROUP(LogicLadderDesignerTestsGroup){ //
 memset(frame_buffer, 0, sizeof(frame_buffer));
 create_storage_0();
 create_storage_1();
-hotreload->view_top_index = 0;
 }
 
 TEST_TEARDOWN() {
@@ -46,8 +42,8 @@ namespace {
 
     class TestableLadder : public Ladder {
       public:
-        int16_t *PublicMorozov_Get_view_top_index() {
-            return &hotreload->view_top_index;
+        int *PublicMorozov_Get_view_top_index() {
+            return &view_top_index;
         }
         int PublicMorozov_GetSelectedNetwork() {
             return GetSelectedNetwork();

--- a/Tests_esp8266/src/logic_Ladder_tests.cpp
+++ b/Tests_esp8266/src/logic_Ladder_tests.cpp
@@ -11,9 +11,7 @@
 
 #include "main/LogicProgram/LogicProgram.h"
 #include "main/redundant_storage.h"
-extern "C" {
-#include "main/hotreload_service.h"
-}
+
 #include "tests_utils.h"
 
 static uint8_t frame_buffer[DISPLAY_WIDTH * DISPLAY_HEIGHT / 8] = {};
@@ -23,7 +21,6 @@ TEST_GROUP(LogicLadderTestsGroup){ //
 memset(frame_buffer, 0, sizeof(frame_buffer));
 create_storage_0();
 create_storage_1();
-hotreload->view_top_index = 0;
 }
 
 TEST_TEARDOWN() {

--- a/Tests_esp8266/src/logic_Ladder_tests.cpp
+++ b/Tests_esp8266/src/logic_Ladder_tests.cpp
@@ -42,7 +42,20 @@ namespace {
 
     class TestableLadder : public Ladder {
       public:
+        static int16_t hotreload_view_top_index;
+        static int16_t hotreload_selected_network;
+
+        TestableLadder()
+            : Ladder([](int16_t view_top_index, int16_t selected_network) {
+                  TestableLadder::hotreload_view_top_index = view_top_index;
+                  TestableLadder::hotreload_selected_network = selected_network;
+              }) {
+            TestableLadder::hotreload_view_top_index = 0;
+            TestableLadder::hotreload_selected_network = 0;
+        }
     };
+    int16_t TestableLadder::hotreload_view_top_index = 0;
+    int16_t TestableLadder::hotreload_selected_network = 0;
 
     class TestableNetwork : public Network, public MonitorLogicElement {
       public:
@@ -151,7 +164,7 @@ namespace {
 } // namespace
 
 TEST(LogicLadderTestsGroup, Store_Load) {
-    Ladder ladder_store;
+    Ladder ladder_store([](int16_t, int16_t) {});
 
     auto network_store = new Network(LogicItemState::lisActive);
     ladder_store.Append(network_store);
@@ -162,7 +175,7 @@ TEST(LogicLadderTestsGroup, Store_Load) {
     network_store->Append(new TestableDirectOutput(MapIO::O1));
     ladder_store.Store();
 
-    Ladder ladder_load;
+    Ladder ladder_load([](int16_t, int16_t) {});
     ladder_load.Load();
 
     CHECK_EQUAL(1, ladder_load.size());
@@ -189,7 +202,7 @@ TEST(LogicLadderTestsGroup, Store_Load) {
 }
 
 TEST(LogicLadderTestsGroup, Remove_elements_before_Load) {
-    Ladder ladder_store;
+    Ladder ladder_store([](int16_t, int16_t) {});
 
     auto network0 = new Network(LogicItemState::lisActive);
     network0->Append(new TestableInputNC(MapIO::DI));
@@ -211,7 +224,7 @@ TEST(LogicLadderTestsGroup, Remove_elements_before_Load) {
     ladder_store.Append(network2);
     ladder_store.Store();
 
-    Ladder ladder_load;
+    Ladder ladder_load([](int16_t, int16_t) {});
     ladder_load.Append(new Network());
     ladder_load.Append(new Network());
     ladder_load.Load();
@@ -224,7 +237,7 @@ TEST(LogicLadderTestsGroup, Remove_elements_before_Load) {
 }
 
 TEST(LogicLadderTestsGroup, initial_load_when_empty_storage) {
-    Ladder ladder_load;
+    Ladder ladder_load([](int16_t, int16_t) {});
     ladder_load.Load();
 
     CHECK_EQUAL(7, ladder_load.size());
@@ -257,7 +270,7 @@ TEST(LogicLadderTestsGroup, Deserialize_with_clear_storage__load_initial) {
                             ladder_storage_name,
                             &storage);
 
-    Ladder ladder_load;
+    Ladder ladder_load([](int16_t, int16_t) {});
     ladder_load.Load();
     CHECK_EQUAL(7, ladder_load.size());
 

--- a/Tests_esp8266/src/logic_Ladder_tests.cpp
+++ b/Tests_esp8266/src/logic_Ladder_tests.cpp
@@ -11,7 +11,9 @@
 
 #include "main/LogicProgram/LogicProgram.h"
 #include "main/redundant_storage.h"
-
+extern "C" {
+#include "main/hotreload_service.h"
+}
 #include "tests_utils.h"
 
 static uint8_t frame_buffer[DISPLAY_WIDTH * DISPLAY_HEIGHT / 8] = {};
@@ -21,6 +23,7 @@ TEST_GROUP(LogicLadderTestsGroup){ //
 memset(frame_buffer, 0, sizeof(frame_buffer));
 create_storage_0();
 create_storage_1();
+hotreload->view_top_index = 0;
 }
 
 TEST_TEARDOWN() {


### PR DESCRIPTION
### !!! MERGE AFTER https://github.com/viordash/AtsPLC/pull/21 !!!

Сохранение в RTC RAM текущего состояния UI Ladder, и последующее восстановление после reset ПЛК.
Сохраняются два параметра:
- `view_top_index`, положение скроллбара
- `selected_network`, номер выбранного нетворка,  если он был выбран или уже редактируется.

Не восстанавливается режим редактирования нетворка или выбор\редактирование элемента в этом нетворке. Перезагрузка сбросит последние изменения и при восстановлении вернет этот нетворк на экран. И также может выделить нетворк если он до перезагрузки был выбран или был в редактировании.