### PR TITLE
Element box filter

### DIFF
--- a/PLC_esp8266/main/LogicProgram/ElementsBox.cpp
+++ b/PLC_esp8266/main/LogicProgram/ElementsBox.cpp
@@ -56,17 +56,6 @@ uint8_t ElementsBox::CalcEntirePlaceWidth(uint8_t fill_wire, LogicElement *sourc
     return source_element_width + fill_wire;
 }
 
-bool ElementsBox::MatchedToStoredElement(LogicElement *source_element, TvElementType element_type) {
-    if (IsInputElement(element_type) && IsOutputElement(source_element->GetElementType())) {
-        return false;
-    }
-
-    if (IsOutputElement(element_type) && IsInputElement(source_element->GetElementType())) {
-        return false;
-    }
-    return true;
-}
-
 bool ElementsBox::CopyParamsToCommonInput(LogicElement *source_element, CommonInput *common_input) {
     if (common_input == NULL) {
         return false;
@@ -175,10 +164,6 @@ void ElementsBox::AppendStandartElement(LogicElement *source_element,
                                         uint8_t *frame_buffer) {
     if (source_element->GetElementType() == element_type) {
         selected_index = size();
-    }
-
-    if (!MatchedToStoredElement(source_element, element_type)) {
-        return;
     }
 
     auto new_element = LogicElementFactory::Create(element_type);

--- a/PLC_esp8266/main/LogicProgram/ElementsBox.h
+++ b/PLC_esp8266/main/LogicProgram/ElementsBox.h
@@ -18,7 +18,6 @@ class ElementsBox : public LogicElement, public std::vector<LogicElement *> {
     uint8_t CalcEntirePlaceWidth(uint8_t fill_wire, LogicElement *source_element);
     void Fill(LogicElement *source_element, bool hide_output_elements);
     void AppendStandartElement(LogicElement *source_element, TvElementType element_type, uint8_t *frame_buffer);
-    bool MatchedToStoredElement(LogicElement *source_element, TvElementType element_type);
     bool CopyParamsToCommonInput(LogicElement *source_element, CommonInput *common_input);
     bool CopyParamsToCommonTimer(LogicElement *source_element, CommonTimer *common_timer);
     bool CopyParamsToCommonOutput(LogicElement *source_element, CommonOutput *common_output);

--- a/Tests_esp8266/src/logic_ElementsBox_tests.cpp
+++ b/Tests_esp8266/src/logic_ElementsBox_tests.cpp
@@ -53,38 +53,8 @@ namespace {
 
 } // namespace
 
-TEST(LogicElementsBoxTestsGroup, box_for_inputs_elements) {
+TEST(LogicElementsBoxTestsGroup, box_fill_elements) {
     InputNC stored_element(MapIO::V1);
-    ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(10, testable.size());
-    CHECK_EQUAL(TvElementType::et_InputNC, testable[0]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_InputNO, testable[1]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_TimerSecs, testable[2]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_TimerMSecs, testable[3]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ComparatorEq, testable[4]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ComparatorGE, testable[5]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ComparatorGr, testable[6]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ComparatorLE, testable[7]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ComparatorLs, testable[8]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_Wire, testable[9]->GetElementType());
-    delete testable.GetSelectedElement();
-}
-
-TEST(LogicElementsBoxTestsGroup, box_for_outputs_elements) {
-    IncOutput stored_element(MapIO::O1);
-    ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(6, testable.size());
-    CHECK_EQUAL(TvElementType::et_DirectOutput, testable[0]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_SetOutput, testable[1]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_ResetOutput, testable[2]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_IncOutput, testable[3]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_DecOutput, testable[4]->GetElementType());
-    CHECK_EQUAL(TvElementType::et_Wire, testable[5]->GetElementType());
-    delete testable.GetSelectedElement();
-}
-
-TEST(LogicElementsBoxTestsGroup, box_for_wire) {
-    Wire stored_element;
     ElementsBox testable(100, &stored_element, false);
     CHECK_EQUAL(15, testable.size());
     CHECK_EQUAL(TvElementType::et_InputNC, testable[0]->GetElementType());
@@ -101,6 +71,7 @@ TEST(LogicElementsBoxTestsGroup, box_for_wire) {
     CHECK_EQUAL(TvElementType::et_ResetOutput, testable[11]->GetElementType());
     CHECK_EQUAL(TvElementType::et_IncOutput, testable[12]->GetElementType());
     CHECK_EQUAL(TvElementType::et_DecOutput, testable[13]->GetElementType());
+    CHECK_EQUAL(TvElementType::et_Wire, testable[14]->GetElementType());
     delete testable.GetSelectedElement();
 }
 
@@ -123,7 +94,7 @@ TEST(LogicElementsBoxTestsGroup, hide_output_elements) {
 TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_input_element) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(10, testable.size());
+    CHECK_EQUAL(15, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonInput = CommonInput::TryToCast(element);
         if (element_as_commonInput != NULL) {
@@ -136,7 +107,7 @@ TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_input_element) {
 TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_comparator_element) {
     ComparatorEq stored_element(42, MapIO::AI);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(10, testable.size());
+    CHECK_EQUAL(15, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonInput = CommonInput::TryToCast(element);
         if (element_as_commonInput != NULL) {
@@ -154,7 +125,7 @@ TEST(LogicElementsBoxTestsGroup,
      takes_params_from_stored_element__set_reference_to_zero_by_default_for_comparators) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(10, testable.size());
+    CHECK_EQUAL(15, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonInput = CommonInput::TryToCast(element);
         if (element_as_commonInput != NULL) {
@@ -171,7 +142,7 @@ TEST(LogicElementsBoxTestsGroup,
 TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_TimerSec_element) {
     TimerSecs stored_element(42);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(10, testable.size());
+    CHECK_EQUAL(15, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonTimer = CommonTimer::TryToCast(element);
         if (element_as_commonTimer != NULL) {
@@ -187,7 +158,7 @@ TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_TimerSec_element) {
 TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_TimerMSec_element) {
     TimerMSecs stored_element(42000);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(10, testable.size());
+    CHECK_EQUAL(15, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonTimer = CommonTimer::TryToCast(element);
         if (element_as_commonTimer != NULL) {
@@ -204,7 +175,7 @@ TEST(LogicElementsBoxTestsGroup,
      takes_params_from_stored_element__set_default_delaytime_for_timers) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(10, testable.size());
+    CHECK_EQUAL(15, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonTimer = CommonTimer::TryToCast(element);
         if (element_as_commonTimer != NULL) {
@@ -225,7 +196,7 @@ TEST(LogicElementsBoxTestsGroup,
 TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_output_element) {
     IncOutput stored_element(MapIO::O1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(6, testable.size());
+    CHECK_EQUAL(15, testable.size());
     for (auto *element : testable) {
         auto *element_as_commonOutput = CommonOutput::TryToCast(element);
         if (element_as_commonOutput != NULL) {
@@ -238,7 +209,7 @@ TEST(LogicElementsBoxTestsGroup, takes_params_from_stored_output_element) {
 TEST(LogicElementsBoxTestsGroup, takes_params_for_wire) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(10, testable.size());
+    CHECK_EQUAL(15, testable.size());
     for (auto *element : testable) {
         auto *element_as_wire = Wire::TryToCast(element);
         if (element_as_wire != NULL) {
@@ -251,7 +222,7 @@ TEST(LogicElementsBoxTestsGroup, takes_params_for_wire) {
 TEST(LogicElementsBoxTestsGroup, no_available_space_for_timers_and_comparators) {
     InputNC stored_element(MapIO::V1);
     ElementsBox testable(7, &stored_element, false);
-    CHECK_EQUAL(3, testable.size());
+    CHECK_EQUAL(6, testable.size());
     delete testable.GetSelectedElement();
 }
 
@@ -316,32 +287,18 @@ TEST(LogicElementsBoxTestsGroup, SelectNext__change__selected_index__to_backward
     testable.SelectNext();
     CHECK_EQUAL(TvElementType::et_Wire, testable.GetElementType());
     testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_ComparatorLs, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_ComparatorLE, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_ComparatorGr, testable.GetElementType());
-    testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_ComparatorGE, testable.GetElementType());
-    testable.SelectNext();
-    delete testable.GetSelectedElement();
-}
 
-TEST(LogicElementsBoxTestsGroup, SelectNext_selecting_elements_in_reverse_loop) {
-    ComparatorEq stored_element(42, MapIO::AI);
-    ElementsBox testable(100, &stored_element, false);
-    CHECK_EQUAL(TvElementType::et_ComparatorEq, testable.GetElementType());
+    CHECK_EQUAL(TvElementType::et_DecOutput, testable.GetElementType());
     testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_TimerMSecs, testable.GetElementType());
+    CHECK_EQUAL(TvElementType::et_IncOutput, testable.GetElementType());
     testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_TimerSecs, testable.GetElementType());
+    CHECK_EQUAL(TvElementType::et_ResetOutput, testable.GetElementType());
     testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_InputNO, testable.GetElementType());
+    CHECK_EQUAL(TvElementType::et_SetOutput, testable.GetElementType());
     testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_InputNC, testable.GetElementType());
+    CHECK_EQUAL(TvElementType::et_DirectOutput, testable.GetElementType());
     testable.SelectNext();
-    CHECK_EQUAL(TvElementType::et_Wire, testable.GetElementType());
-    testable.SelectNext();
+
     CHECK_EQUAL(TvElementType::et_ComparatorLs, testable.GetElementType());
     testable.SelectNext();
     CHECK_EQUAL(TvElementType::et_ComparatorLE, testable.GetElementType());
@@ -365,6 +322,16 @@ TEST(LogicElementsBoxTestsGroup, SelectPrior_selecting_elements_in_loop) {
     CHECK_EQUAL(TvElementType::et_ComparatorLE, testable.GetElementType());
     testable.SelectPrior();
     CHECK_EQUAL(TvElementType::et_ComparatorLs, testable.GetElementType());
+    testable.SelectPrior();
+    CHECK_EQUAL(TvElementType::et_DirectOutput, testable.GetElementType());
+    testable.SelectPrior();
+    CHECK_EQUAL(TvElementType::et_SetOutput, testable.GetElementType());
+    testable.SelectPrior();
+    CHECK_EQUAL(TvElementType::et_ResetOutput, testable.GetElementType());
+    testable.SelectPrior();
+    CHECK_EQUAL(TvElementType::et_IncOutput, testable.GetElementType());
+    testable.SelectPrior();
+    CHECK_EQUAL(TvElementType::et_DecOutput, testable.GetElementType());
     testable.SelectPrior();
     CHECK_EQUAL(TvElementType::et_Wire, testable.GetElementType());
     testable.SelectPrior();

--- a/Tests_esp8266/src/logic_Network_tests.cpp
+++ b/Tests_esp8266/src/logic_Network_tests.cpp
@@ -427,7 +427,7 @@ TEST(LogicNetworkTestsGroup,
     CHECK_EQUAL(TvElementType::et_DirectOutput, expectedElementBox->GetElementType());
     CHECK_TRUE(expectedElementBox->Editing());
     auto elementBox = static_cast<ElementsBox *>(expectedElementBox);
-    CHECK_EQUAL(6, elementBox->size());
+    CHECK_EQUAL(15, elementBox->size());
 
     testable.SelectPrior();
     CHECK_EQUAL(TvElementType::et_SetOutput, expectedElementBox->GetElementType());


### PR DESCRIPTION
!!! MERGE AFTER https://github.com/viordash/AtsPLC/pull/24 !!!

Убран фильтр элементов в ElementBox, который фильтровал элементы в списке в соответствии с типом редактируемого элемента. Т.е. если редактировался элемент из группы Inputs, то и на выбор для замены предлагались также элементы из этой группы.
Теперь правильность логики элементов в нетворке должен проверять сам разработчик логики программы.
