### PR TITLE
pass Option button handling to all elements

### DIFF
--- a/PLC_esp8266/main/Display/EditableElement.h
+++ b/PLC_esp8266/main/Display/EditableElement.h
@@ -50,4 +50,5 @@ class EditableElement {
     virtual void PageUp() = 0;
     virtual void PageDown() = 0;
     virtual void Change() = 0;
+    virtual void Option() = 0;
 };

--- a/PLC_esp8266/main/LogicProgram/Bindings/WiFiBinding.cpp
+++ b/PLC_esp8266/main/LogicProgram/Bindings/WiFiBinding.cpp
@@ -358,6 +358,9 @@ void WiFiBinding::Change() {
             break;
     }
 }
+void WiFiBinding::Option() {
+}
+
 void WiFiBinding::EndEditing() {
     ssid_size = 0;
     while (ssid_size < sizeof(ssid) && ssid[ssid_size] != 0 && ssid[ssid_size] != place_new_char) {

--- a/PLC_esp8266/main/LogicProgram/Bindings/WiFiBinding.h
+++ b/PLC_esp8266/main/LogicProgram/Bindings/WiFiBinding.h
@@ -59,6 +59,7 @@ class WiFiBinding : public LogicElement, public InputElement, public LabeledLogi
     void PageUp() override;
     void PageDown() override;
     void Change() override;
+    void Option() override;
 
     const char *GetSsid();
     void SetSsid(const char *ssid);

--- a/PLC_esp8266/main/LogicProgram/ElementsBox.cpp
+++ b/PLC_esp8266/main/LogicProgram/ElementsBox.cpp
@@ -371,6 +371,22 @@ void ElementsBox::Change() {
     GetSelectedElement()->Change();
 }
 
+void ElementsBox::Option() {
+    bool selected_in_editing = GetSelectedElement()->Editing();
+
+    ESP_LOGI(TAG_ElementsBox,
+             "Option, selected_index:%d, in_editing:%d",
+             selected_index,
+             selected_in_editing);
+
+    if (!selected_in_editing) {
+        ESP_LOGE(TAG_ElementsBox, "Option");
+        return;
+    }
+
+    GetSelectedElement()->Option();
+}
+
 bool ElementsBox::EditingCompleted() {
     bool selected_in_editing = GetSelectedElement()->Editing();
     ESP_LOGI(TAG_ElementsBox,

--- a/PLC_esp8266/main/LogicProgram/ElementsBox.h
+++ b/PLC_esp8266/main/LogicProgram/ElementsBox.h
@@ -51,5 +51,6 @@ class ElementsBox : public LogicElement, public std::vector<LogicElement *> {
     void PageUp() override final;
     void PageDown() override final;
     void Change() override final;
+    void Option() override final;
     bool EditingCompleted();
 };

--- a/PLC_esp8266/main/LogicProgram/Inputs/CommonComparator.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/CommonComparator.cpp
@@ -240,3 +240,6 @@ void CommonComparator::Change() {
             return;
     }
 }
+
+void CommonComparator::Option() {
+}

--- a/PLC_esp8266/main/LogicProgram/Inputs/CommonComparator.h
+++ b/PLC_esp8266/main/LogicProgram/Inputs/CommonComparator.h
@@ -44,4 +44,5 @@ class CommonComparator : public CommonInput {
     void PageUp() override;
     void PageDown() override;
     void Change() override;
+    void Option() override;
 };

--- a/PLC_esp8266/main/LogicProgram/Inputs/CommonInput.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/CommonInput.cpp
@@ -138,3 +138,6 @@ void CommonInput::Change() {
             break;
     }
 }
+
+void CommonInput::Option() {
+}

--- a/PLC_esp8266/main/LogicProgram/Inputs/CommonInput.h
+++ b/PLC_esp8266/main/LogicProgram/Inputs/CommonInput.h
@@ -33,4 +33,5 @@ class CommonInput : public LogicElement, public InputElement, public LabeledLogi
     void PageUp() override;
     void PageDown() override;
     void Change() override;
+    void Option() override;
 };

--- a/PLC_esp8266/main/LogicProgram/Inputs/Indicator.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/Indicator.cpp
@@ -157,7 +157,8 @@ IRAM_ATTR bool Indicator::Render(uint8_t *fb, LogicItemState prev_elem_state, Po
                                && (Indicator::EditingPropertyId)editing_property_id
                                       == Indicator::EditingPropertyId::ciepi_ConfigureIOAdr
                                && Blinking_50();
-    res = blink_label_on_editing || (draw_text_f8X14(fb, top_left.x + 4, top_left.y + 4, label) > 0);
+    res =
+        blink_label_on_editing || (draw_text_f8X14(fb, top_left.x + 4, top_left.y + 4, label) > 0);
     if (!res) {
         return res;
     }
@@ -552,6 +553,9 @@ void Indicator::Change() {
             EndEditing();
             break;
     }
+}
+
+void Indicator::Option() {
 }
 
 const AllowedIO Indicator::GetAllowedInputs() {

--- a/PLC_esp8266/main/LogicProgram/Inputs/Indicator.h
+++ b/PLC_esp8266/main/LogicProgram/Inputs/Indicator.h
@@ -80,6 +80,7 @@ class Indicator : public LogicElement, public InputElement, public LabeledLogicI
     void PageUp() override;
     void PageDown() override;
     void Change() override;
+    void Option() override;
 
     float GetLowScale();
     void SetLowScale(float scale);

--- a/PLC_esp8266/main/LogicProgram/Inputs/TimerMSecs.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/TimerMSecs.cpp
@@ -143,3 +143,6 @@ void TimerMSecs::Change() {
             break;
     }
 }
+
+void TimerMSecs::Option() {
+}

--- a/PLC_esp8266/main/LogicProgram/Inputs/TimerMSecs.h
+++ b/PLC_esp8266/main/LogicProgram/Inputs/TimerMSecs.h
@@ -35,4 +35,5 @@ class TimerMSecs : public CommonTimer {
     void PageUp() override;
     void PageDown() override;
     void Change() override;
+    void Option() override;
 };

--- a/PLC_esp8266/main/LogicProgram/Inputs/TimerSecs.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/TimerSecs.cpp
@@ -145,3 +145,6 @@ void TimerSecs::Change() {
             break;
     }
 }
+
+void TimerSecs::Option() {
+}

--- a/PLC_esp8266/main/LogicProgram/Inputs/TimerSecs.h
+++ b/PLC_esp8266/main/LogicProgram/Inputs/TimerSecs.h
@@ -39,4 +39,5 @@ class TimerSecs : public CommonTimer {
     void PageUp() override;
     void PageDown() override;
     void Change() override;
+    void Option() override;
 };

--- a/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
+++ b/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
@@ -216,13 +216,13 @@ void Ladder::HandleButtonOption() {
     auto selected_network = GetSelectedNetwork();
     auto design_state = GetDesignState(selected_network);
 
-    ESP_LOGD(TAG_Ladder,
+    ESP_LOGI(TAG_Ladder,
              "HandleButtonOption, %u, selected_network:%d",
              (unsigned)design_state,
              selected_network);
     switch (design_state) {
         case EditableElement::ElementState::des_Editing:
-            (*this)[selected_network]->SwitchState();
+            (*this)[selected_network]->Option();
             break;
 
         default:

--- a/PLC_esp8266/main/LogicProgram/Network.cpp
+++ b/PLC_esp8266/main/LogicProgram/Network.cpp
@@ -415,6 +415,20 @@ void Network::EndEditing() {
     RemoveSpaceForNewElement();
 }
 
+void Network::Option() {
+    auto selected_element = GetSelectedElement();
+
+    ESP_LOGI(TAG_Network, "Option, selected_element:%d", selected_element);
+    if (selected_element >= 0) {
+        if ((*this)[selected_element]->Editing()) {
+            static_cast<ElementsBox *>((*this)[selected_element])->Option();
+            return;
+        }
+    } else {
+        SwitchState();
+    }
+}
+
 int Network::GetSelectedElement() {
     for (int i = 0; i < (int)size(); i++) {
         auto element = (*this)[i];

--- a/PLC_esp8266/main/LogicProgram/Network.h
+++ b/PLC_esp8266/main/LogicProgram/Network.h
@@ -41,6 +41,7 @@ class Network : public std::vector<LogicElement *>, public EditableElement {
     void Change();
     void BeginEditing() override final;
     void EndEditing() override final;
+    void Option() override final;
     int GetSelectedElement();
 
     void SwitchState();

--- a/PLC_esp8266/main/LogicProgram/Outputs/CommonOutput.cpp
+++ b/PLC_esp8266/main/LogicProgram/Outputs/CommonOutput.cpp
@@ -153,3 +153,6 @@ void CommonOutput::Change() {
             break;
     }
 }
+
+void CommonOutput::Option() {
+}

--- a/PLC_esp8266/main/LogicProgram/Outputs/CommonOutput.h
+++ b/PLC_esp8266/main/LogicProgram/Outputs/CommonOutput.h
@@ -38,4 +38,5 @@ class CommonOutput : public LogicElement, public InputOutputElement, public Labe
     void PageUp() override;
     void PageDown() override;
     void Change() override;
+    void Option() override;
 };

--- a/PLC_esp8266/main/LogicProgram/Wire.cpp
+++ b/PLC_esp8266/main/LogicProgram/Wire.cpp
@@ -100,6 +100,9 @@ void Wire::Change() {
     EndEditing();
 }
 
+void Wire::Option() {
+}
+
 Wire *Wire::TryToCast(LogicElement *logic_element) {
     switch (logic_element->GetElementType()) {
         case TvElementType::et_Wire:

--- a/PLC_esp8266/main/LogicProgram/Wire.h
+++ b/PLC_esp8266/main/LogicProgram/Wire.h
@@ -27,6 +27,7 @@ class Wire : public LogicElement {
     void PageUp() override;
     void PageDown() override;
     void Change() override;
+    void Option() override;
 
     static Wire *TryToCast(LogicElement *logic_element);
 };

--- a/Tests_esp8266/src/logic_CommonTimer_tests.cpp
+++ b/Tests_esp8266/src/logic_CommonTimer_tests.cpp
@@ -90,6 +90,8 @@ namespace {
         }
         void Change() {
         }
+        void Option() {
+        }
         bool EditingCompleted() {
             return true;
         }


### PR DESCRIPTION
У каждого элемента можно индивидуально обработать Option (долгое нажатие на Select\Ok) при редактировании элемента. На данном этапе все методы у элементов пустые, т.е. обработка Option для элементов не используется