### PR TITLE
Event loop in design state

### DIFF
--- a/PLC_esp8266/main/LogicProgram/Controller.cpp
+++ b/PLC_esp8266/main/LogicProgram/Controller.cpp
@@ -112,6 +112,7 @@ void Controller::ProcessTask(void *parm) {
         ladder->SetViewTopIndex(hotreload->view_top_index);
         ladder->SetSelectedNetworkIndex(hotreload->selected_network);
     }
+    ladder->AtLeastOneNetwork();
 
     TaskHandle_t render_task_handle;
     ESP_ERROR_CHECK(xTaskCreate(RenderTask,
@@ -204,7 +205,6 @@ void Controller::RenderTask(void *parm) {
 
     uint32_t ulNotifiedValue = {};
 
-    ladder->AtLeastOneNetwork();
     while (Controller::runned || (ulNotifiedValue & STOP_RENDER_TASK)) {
         BaseType_t xResult =
             xTaskNotifyWait(0,

--- a/PLC_esp8266/main/LogicProgram/Controller.cpp
+++ b/PLC_esp8266/main/LogicProgram/Controller.cpp
@@ -181,7 +181,7 @@ void Controller::ProcessTask(void *parm) {
             ESP_LOGD(TAG_Controller, "any_changes_in_actions");
             Controller::RequestWakeupMs((void *)Controller::ProcessTask, 0);
         } else if (Controller::force_process_loop) {
-            ESP_LOGI(TAG_Controller, "force_process_loop");
+            ESP_LOGD(TAG_Controller, "force_process_loop");
             Controller::RequestWakeupMs((void *)Controller::ProcessTask, 200);
         }
         

--- a/PLC_esp8266/main/LogicProgram/Controller.h
+++ b/PLC_esp8266/main/LogicProgram/Controller.h
@@ -29,6 +29,7 @@ extern "C" {
 class Controller {
   protected:
     static bool runned;
+    static bool force_process_loop;
     static EventGroupHandle_t gpio_events;
     static TaskHandle_t process_task_handle;
     static Ladder *ladder;

--- a/PLC_esp8266/main/LogicProgram/ElementsBox.cpp
+++ b/PLC_esp8266/main/LogicProgram/ElementsBox.cpp
@@ -31,7 +31,7 @@ ElementsBox::ElementsBox(uint8_t fill_wire, LogicElement *source_element, bool h
     source_element->BeginEditing();
     selected_index = 0;
     force_do_action_result = false;
-
+    state = source_element->state;
     CalcEntirePlaceWidth(source_element);
     place_width = source_element_width + fill_wire;
     Fill(source_element, hide_output_elements);

--- a/PLC_esp8266/main/LogicProgram/Ladder.cpp
+++ b/PLC_esp8266/main/LogicProgram/Ladder.cpp
@@ -98,7 +98,5 @@ void Ladder::AtLeastOneNetwork() {
         return;
     }
     ESP_LOGI(TAG_Ladder, "requires at least one network");
-    auto new_network = new Network(LogicItemState::lisActive);
-    Append(new_network);
-    new_network->Select();
+    HandleButtonSelect();
 }

--- a/PLC_esp8266/main/LogicProgram/Ladder.h
+++ b/PLC_esp8266/main/LogicProgram/Ladder.h
@@ -49,7 +49,6 @@ class Ladder : public std::vector<Network *> {
     void HandleButtonPageDown();
     void HandleButtonSelect();
     void HandleButtonOption();
-    bool ForcePeriodicRendering();
 
     void Load();
     void Store();

--- a/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
+++ b/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
@@ -244,17 +244,3 @@ bool Ladder::RemoveNetworkIfEmpty(int network_id) {
     }
     return false;
 }
-
-bool Ladder::ForcePeriodicRendering() {
-    auto selected_network = GetSelectedNetwork();
-    auto design_state = GetDesignState(selected_network);
-
-    switch (design_state) {
-        case EditableElement::ElementState::des_Selected:
-        case EditableElement::ElementState::des_Editing:
-            return true;
-
-        default:
-            return false;
-    }
-}

--- a/PLC_esp8266/main/LogicProgram/Network.cpp
+++ b/PLC_esp8266/main/LogicProgram/Network.cpp
@@ -351,7 +351,7 @@ void Network::AddSpaceForNewElement() {
     wire->SetWidth(wire_width);
     if (EnoughSpaceForNewElement(wire)) {
         ESP_LOGI(TAG_Network, "insert wire element");
-
+        LogicItemState wire_state = state;
         auto it = begin();
         while (it != end()) {
             auto element = *it;
@@ -361,8 +361,10 @@ void Network::AddSpaceForNewElement() {
             if (is_output_element) {
                 break;
             }
+            wire_state = element->state;
             it++;
         }
+        wire->state = wire_state;
         insert(it, wire);
 
     } else {


### PR DESCRIPTION
Основная цель этого ПР, исправить индикацию состояний линий (active\passive) network при дизайне. Был минорный UI баг, когда при старте редактирования нового network-а, линия отображалась пунктиром как passive.
Изменен подход для периодического рендеринга в режиме дизайна. Вместо постоянного опроса статуса выделенного network, теперь при переходе в режим дизайна, коллбек cb_UI_state_changed с выделенным network, устанавливает флаг `Controller::force_process_loop` и пробуждает таску процесса контроллера. С этим флагом, процесс постоянно добавляет запрос на пробуждение через 200 мс.