### PR TITLE
Process wakeup requests priority

### DIFF
--- a/PLC_esp8266/main/LogicProgram/Controller.cpp
+++ b/PLC_esp8266/main/LogicProgram/Controller.cpp
@@ -124,7 +124,7 @@ void Controller::ProcessTask(void *parm) {
     const uint32_t first_iteration_delay = 0;
     Controller::RequestWakeupMs((void *)Controller::ProcessTask,
                                 first_iteration_delay,
-                                ProcessWakeupRequestPriority::pwrp_Highest);
+                                ProcessWakeupRequestPriority::pwrp_Critical);
     bool need_render = true;
     while (Controller::runned) {
         EventBits_t uxBits = xEventGroupWaitBits(Controller::gpio_events,
@@ -183,13 +183,13 @@ void Controller::ProcessTask(void *parm) {
             ESP_LOGD(TAG_Controller, "any_changes_in_actions");
             Controller::RequestWakeupMs((void *)Controller::ProcessTask,
                                         0,
-                                        ProcessWakeupRequestPriority::pwrp_Idle);
+                                        ProcessWakeupRequestPriority::pwrp_Critical);
         } else if (Controller::force_process_loop) {
             ESP_LOGD(TAG_Controller, "force_process_loop");
             const uint32_t process_loop_cycle_ms = 200;
             Controller::RequestWakeupMs((void *)Controller::ProcessTask,
                                         process_loop_cycle_ms,
-                                        ProcessWakeupRequestPriority::pwrp_Low);
+                                        ProcessWakeupRequestPriority::pwrp_Idle);
         }
 
         need_render |= force_render;

--- a/PLC_esp8266/main/LogicProgram/Controller.cpp
+++ b/PLC_esp8266/main/LogicProgram/Controller.cpp
@@ -122,9 +122,9 @@ void Controller::ProcessTask(void *parm) {
     xEventGroupClearBits(Controller::gpio_events, GPIO_EVENTS_ALL_BITS | WAKEUP_PROCESS_TASK);
 
     const uint32_t first_iteration_delay = 0;
-    processWakeupService->Request((void *)Controller::ProcessTask,
-                                  first_iteration_delay,
-                                  ProcessWakeupRequestPriority::pwrp_Normal);
+    Controller::RequestWakeupMs((void *)Controller::ProcessTask,
+                                first_iteration_delay,
+                                ProcessWakeupRequestPriority::pwrp_Highest);
     bool need_render = true;
     while (Controller::runned) {
         EventBits_t uxBits = xEventGroupWaitBits(Controller::gpio_events,
@@ -183,13 +183,13 @@ void Controller::ProcessTask(void *parm) {
             ESP_LOGD(TAG_Controller, "any_changes_in_actions");
             Controller::RequestWakeupMs((void *)Controller::ProcessTask,
                                         0,
-                                        ProcessWakeupRequestPriority::pwrp_Normal);
+                                        ProcessWakeupRequestPriority::pwrp_Idle);
         } else if (Controller::force_process_loop) {
             ESP_LOGD(TAG_Controller, "force_process_loop");
             const uint32_t process_loop_cycle_ms = 200;
             Controller::RequestWakeupMs((void *)Controller::ProcessTask,
                                         process_loop_cycle_ms,
-                                        ProcessWakeupRequestPriority::pwrp_Normal);
+                                        ProcessWakeupRequestPriority::pwrp_Low);
         }
 
         need_render |= force_render;

--- a/PLC_esp8266/main/LogicProgram/Controller.cpp
+++ b/PLC_esp8266/main/LogicProgram/Controller.cpp
@@ -122,7 +122,9 @@ void Controller::ProcessTask(void *parm) {
     xEventGroupClearBits(Controller::gpio_events, GPIO_EVENTS_ALL_BITS | WAKEUP_PROCESS_TASK);
 
     const uint32_t first_iteration_delay = 0;
-    processWakeupService->Request((void *)Controller::ProcessTask, first_iteration_delay);
+    processWakeupService->Request((void *)Controller::ProcessTask,
+                                  first_iteration_delay,
+                                  ProcessWakeupRequestPriority::pwrp_Normal);
     bool need_render = true;
     while (Controller::runned) {
         EventBits_t uxBits = xEventGroupWaitBits(Controller::gpio_events,
@@ -179,11 +181,15 @@ void Controller::ProcessTask(void *parm) {
         need_render |= any_changes_in_actions;
         if (any_changes_in_actions) {
             ESP_LOGD(TAG_Controller, "any_changes_in_actions");
-            Controller::RequestWakeupMs((void *)Controller::ProcessTask, 0);
+            Controller::RequestWakeupMs((void *)Controller::ProcessTask,
+                                        0,
+                                        ProcessWakeupRequestPriority::pwrp_Normal);
         } else if (Controller::force_process_loop) {
             ESP_LOGD(TAG_Controller, "force_process_loop");
             const uint32_t process_loop_cycle_ms = 200;
-            Controller::RequestWakeupMs((void *)Controller::ProcessTask, process_loop_cycle_ms);
+            Controller::RequestWakeupMs((void *)Controller::ProcessTask,
+                                        process_loop_cycle_ms,
+                                        ProcessWakeupRequestPriority::pwrp_Normal);
         }
 
         need_render |= force_render;
@@ -258,8 +264,10 @@ void Controller::CommitChanges() {
     Controller::V4.CommitChanges();
 }
 
-bool Controller::RequestWakeupMs(void *id, uint32_t delay_ms) {
-    return processWakeupService->Request(id, delay_ms);
+bool Controller::RequestWakeupMs(void *id,
+                                 uint32_t delay_ms,
+                                 ProcessWakeupRequestPriority priority) {
+    return processWakeupService->Request(id, delay_ms, priority);
 }
 
 void Controller::RemoveRequestWakeupMs(void *id) {

--- a/PLC_esp8266/main/LogicProgram/Controller.h
+++ b/PLC_esp8266/main/LogicProgram/Controller.h
@@ -55,7 +55,7 @@ class Controller {
     static ControllerVariable V3;
     static ControllerVariable V4;
 
-    static bool RequestWakeupMs(void *id, uint32_t delay_ms);
+    static bool RequestWakeupMs(void *id, uint32_t delay_ms, ProcessWakeupRequestPriority priority);
     static void RemoveRequestWakeupMs(void *id);
     static void RemoveExpiredWakeupRequests();
 

--- a/PLC_esp8266/main/LogicProgram/ControllerAI.cpp
+++ b/PLC_esp8266/main/LogicProgram/ControllerAI.cpp
@@ -13,7 +13,9 @@ void ControllerAI::FetchValue() {
     if (!required_reading) {
         return;
     }
-    if (!Controller::RequestWakeupMs((void *)&Controller::AI, read_adc_max_period_ms)) {
+    if (!Controller::RequestWakeupMs((void *)&Controller::AI,
+                                     read_adc_max_period_ms,
+                                     ProcessWakeupRequestPriority::pwrp_Normal)) {
         return;
     }
     required_reading = false;

--- a/PLC_esp8266/main/LogicProgram/ControllerAI.cpp
+++ b/PLC_esp8266/main/LogicProgram/ControllerAI.cpp
@@ -15,7 +15,7 @@ void ControllerAI::FetchValue() {
     }
     if (!Controller::RequestWakeupMs((void *)&Controller::AI,
                                      read_adc_max_period_ms,
-                                     ProcessWakeupRequestPriority::pwrp_Normal)) {
+                                     ProcessWakeupRequestPriority::pwrp_Idle)) {
         return;
     }
     required_reading = false;

--- a/PLC_esp8266/main/LogicProgram/Inputs/CommonTimer.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/CommonTimer.cpp
@@ -27,7 +27,7 @@ bool CommonTimer::DoAction(bool prev_elem_changed, LogicItemState prev_elem_stat
         Controller::RemoveRequestWakeupMs(this);
         Controller::RequestWakeupMs(this,
                                     delay_time_us / 1000LL,
-                                    ProcessWakeupRequestPriority::pwrp_High);
+                                    ProcessWakeupRequestPriority::pwrp_Critical);
     }
 
     bool any_changes = false;
@@ -40,7 +40,7 @@ bool CommonTimer::DoAction(bool prev_elem_changed, LogicItemState prev_elem_stat
         bool timer_completed =
             Controller::RequestWakeupMs(this,
                                         delay_time_us / 1000LL,
-                                        ProcessWakeupRequestPriority::pwrp_High);
+                                        ProcessWakeupRequestPriority::pwrp_Critical);
         if (timer_completed) {
             state = LogicItemState::lisActive;
         }

--- a/PLC_esp8266/main/LogicProgram/Inputs/CommonTimer.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/CommonTimer.cpp
@@ -25,7 +25,9 @@ bool CommonTimer::DoAction(bool prev_elem_changed, LogicItemState prev_elem_stat
     }
     if (prev_elem_changed && prev_elem_state == LogicItemState::lisActive) {
         Controller::RemoveRequestWakeupMs(this);
-        Controller::RequestWakeupMs(this, delay_time_us / 1000LL);
+        Controller::RequestWakeupMs(this,
+                                    delay_time_us / 1000LL,
+                                    ProcessWakeupRequestPriority::pwrp_Normal);
     }
 
     bool any_changes = false;
@@ -35,7 +37,10 @@ bool CommonTimer::DoAction(bool prev_elem_changed, LogicItemState prev_elem_stat
     if (prev_elem_state != LogicItemState::lisActive) {
         state = LogicItemState::lisPassive;
     } else if (state != LogicItemState::lisActive) {
-        bool timer_completed = Controller::RequestWakeupMs(this, delay_time_us / 1000LL);
+        bool timer_completed =
+            Controller::RequestWakeupMs(this,
+                                        delay_time_us / 1000LL,
+                                        ProcessWakeupRequestPriority::pwrp_Normal);
         if (timer_completed) {
             state = LogicItemState::lisActive;
         }

--- a/PLC_esp8266/main/LogicProgram/Inputs/CommonTimer.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/CommonTimer.cpp
@@ -27,7 +27,7 @@ bool CommonTimer::DoAction(bool prev_elem_changed, LogicItemState prev_elem_stat
         Controller::RemoveRequestWakeupMs(this);
         Controller::RequestWakeupMs(this,
                                     delay_time_us / 1000LL,
-                                    ProcessWakeupRequestPriority::pwrp_Normal);
+                                    ProcessWakeupRequestPriority::pwrp_High);
     }
 
     bool any_changes = false;
@@ -40,7 +40,7 @@ bool CommonTimer::DoAction(bool prev_elem_changed, LogicItemState prev_elem_stat
         bool timer_completed =
             Controller::RequestWakeupMs(this,
                                         delay_time_us / 1000LL,
-                                        ProcessWakeupRequestPriority::pwrp_Normal);
+                                        ProcessWakeupRequestPriority::pwrp_High);
         if (timer_completed) {
             state = LogicItemState::lisActive;
         }

--- a/PLC_esp8266/main/LogicProgram/Inputs/Indicator.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/Indicator.cpp
@@ -91,7 +91,7 @@ bool Indicator::DoAction(bool prev_elem_changed, LogicItemState prev_elem_state)
         state = LogicItemState::lisActive;
         if (Controller::RequestWakeupMs(this,
                                         update_period_ms,
-                                        ProcessWakeupRequestPriority::pwrp_Normal)) {
+                                        ProcessWakeupRequestPriority::pwrp_Low)) {
             any_changes = true;
 
             switch (editing_property_id) {

--- a/PLC_esp8266/main/LogicProgram/Inputs/Indicator.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/Indicator.cpp
@@ -89,7 +89,9 @@ bool Indicator::DoAction(bool prev_elem_changed, LogicItemState prev_elem_state)
 
     if (prev_elem_state == LogicItemState::lisActive) {
         state = LogicItemState::lisActive;
-        if (Controller::RequestWakeupMs(this, update_period_ms)) {
+        if (Controller::RequestWakeupMs(this,
+                                        update_period_ms,
+                                        ProcessWakeupRequestPriority::pwrp_Normal)) {
             any_changes = true;
 
             switch (editing_property_id) {

--- a/PLC_esp8266/main/LogicProgram/Inputs/Indicator.cpp
+++ b/PLC_esp8266/main/LogicProgram/Inputs/Indicator.cpp
@@ -91,9 +91,8 @@ bool Indicator::DoAction(bool prev_elem_changed, LogicItemState prev_elem_state)
         state = LogicItemState::lisActive;
         if (Controller::RequestWakeupMs(this,
                                         update_period_ms,
-                                        ProcessWakeupRequestPriority::pwrp_Low)) {
+                                        ProcessWakeupRequestPriority::pwrp_Idle)) {
             any_changes = true;
-
             switch (editing_property_id) {
                 case Indicator::EditingPropertyId::ciepi_None:
                     PrintOutValue(Input->ReadValue());

--- a/PLC_esp8266/main/LogicProgram/ProcessWakeupService.cpp
+++ b/PLC_esp8266/main/LogicProgram/ProcessWakeupService.cpp
@@ -34,7 +34,7 @@ bool ProcessWakeupService::Request(void *id,
                                   && (upper_req.next_time - next_time) < idle_dead_band_us;
         if (request_can_be_joined) {
             ESP_LOGD(TAG_ProcessWakeupService,
-                     "Request is skipped in:%u, %p, diff:%d, next:%u",
+                     "Request is joined in:%u, %p, diff:%d, next:%u",
                      delay_ms,
                      id,
                      (int32_t)(upper_req.next_time - next_time),

--- a/PLC_esp8266/main/LogicProgram/ProcessWakeupService.cpp
+++ b/PLC_esp8266/main/LogicProgram/ProcessWakeupService.cpp
@@ -10,7 +10,9 @@
 
 static const char *TAG_ProcessWakeupService = "ProcessWakeupService";
 
-bool ProcessWakeupService::Request(void *id, uint32_t delay_ms) {
+bool ProcessWakeupService::Request(void *id,
+                                   uint32_t delay_ms,
+                                   ProcessWakeupRequestPriority priority) {
     bool request_already_in = ids.find(id) != ids.end();
     if (request_already_in) {
         ESP_LOGD(TAG_ProcessWakeupService,
@@ -24,7 +26,7 @@ bool ProcessWakeupService::Request(void *id, uint32_t delay_ms) {
     auto current_time = (uint64_t)esp_timer_get_time();
     auto next_time = current_time + (delay_ms * 1000);
 
-    requests.insert({ id, next_time });
+    requests.insert({ id, next_time, priority });
     ids.insert(id);
 
     ESP_LOGD(TAG_ProcessWakeupService,

--- a/PLC_esp8266/main/LogicProgram/ProcessWakeupService.h
+++ b/PLC_esp8266/main/LogicProgram/ProcessWakeupService.h
@@ -10,10 +10,7 @@
 
 enum ProcessWakeupRequestPriority {
     pwrp_Idle,
-    pwrp_Low,
-    pwrp_Normal,
-    pwrp_High,
-    pwrp_Highest,
+    pwrp_Critical,
 };
 
 struct ProcessWakeupRequestData {
@@ -45,6 +42,7 @@ struct ProcessWakeupRequestDataCmp {
 
 class ProcessWakeupService {
   protected:
+    static const uint64_t idle_dead_band_us = 100000;
     static const uint32_t default_delay = -1;
     std::set<ProcessWakeupRequestData, ProcessWakeupRequestDataCmp> requests;
     std::unordered_set<void *> ids;

--- a/PLC_esp8266/main/LogicProgram/ProcessWakeupService.h
+++ b/PLC_esp8266/main/LogicProgram/ProcessWakeupService.h
@@ -8,9 +8,18 @@
 #include <unistd.h>
 #include <unordered_set>
 
+enum ProcessWakeupRequestPriority {
+    pwrp_Idle,
+    pwrp_Low,
+    pwrp_Normal,
+    pwrp_High,
+    pwrp_Highest,
+};
+
 struct ProcessWakeupRequestData {
     void *id;
     uint64_t next_time;
+    ProcessWakeupRequestPriority priority;
 };
 
 struct ProcessWakeupRequestDataCmp {
@@ -41,7 +50,7 @@ class ProcessWakeupService {
     std::unordered_set<void *> ids;
 
   public:
-    bool Request(void *id, uint32_t delay_ms);
+    bool Request(void *id, uint32_t delay_ms, ProcessWakeupRequestPriority priority);
     void RemoveRequest(void *id);
     uint32_t Get();
     int RemoveExpired();

--- a/PLC_esp8266/main/WiFi/WiFiService_Station.cpp
+++ b/PLC_esp8266/main/WiFi/WiFiService_Station.cpp
@@ -107,7 +107,8 @@ void WiFiService::StationTask(RequestItem *request) {
 
             connect_retries_num++;
             ESP_LOGI(TAG_WiFiService_Station,
-                     "failed. reconnect, num:%d of %d",
+                     "'%s' failed. reconnect, num:%d of %d",
+                     settings.wifi_station.ssid,
                      connect_retries_num,
                      max_retry_count);
 

--- a/Tests_esp8266/src/logic_ProcessWakeupService_tests.cpp
+++ b/Tests_esp8266/src/logic_ProcessWakeupService_tests.cpp
@@ -53,18 +53,18 @@ TEST(ProcessWakeupServiceTestsGroup, Requests_are_unique_by_id) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Critical);
     CHECK_EQUAL(1, testable.PublicMorozov_Get_requests_size());
-    testable.Request((void *)2, 20, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)2, 20, ProcessWakeupRequestPriority::pwrp_Critical);
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
-    testable.Request((void *)1, 11, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)1, 11, ProcessWakeupRequestPriority::pwrp_Critical);
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
-    testable.Request((void *)2, 21, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)2, 21, ProcessWakeupRequestPriority::pwrp_Critical);
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)3, 10, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)3, 10, ProcessWakeupRequestPriority::pwrp_Critical);
     CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
-    testable.Request((void *)4, 20, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)4, 20, ProcessWakeupRequestPriority::pwrp_Critical);
     CHECK_EQUAL(4, testable.PublicMorozov_Get_requests_size());
 }
 
@@ -76,10 +76,10 @@ TEST(ProcessWakeupServiceTestsGroup, Requests_returns_true_if_successfully_added
 
     TestableProcessWakeupService testable;
 
-    CHECK_TRUE(testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Normal));
-    CHECK_FALSE(testable.Request((void *)1, 11, ProcessWakeupRequestPriority::pwrp_Normal));
-    CHECK_TRUE(testable.Request((void *)2, 10, ProcessWakeupRequestPriority::pwrp_Normal));
-    CHECK_FALSE(testable.Request((void *)2, 11, ProcessWakeupRequestPriority::pwrp_Normal));
+    CHECK_TRUE(testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Critical));
+    CHECK_FALSE(testable.Request((void *)1, 11, ProcessWakeupRequestPriority::pwrp_Critical));
+    CHECK_TRUE(testable.Request((void *)2, 10, ProcessWakeupRequestPriority::pwrp_Critical));
+    CHECK_FALSE(testable.Request((void *)2, 11, ProcessWakeupRequestPriority::pwrp_Critical));
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
 }
 
@@ -91,10 +91,10 @@ TEST(ProcessWakeupServiceTestsGroup, Requests_ordered_by_next_tick) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)2, 2000, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)3, 100, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)1, 1000, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)4, 1000, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)2, 2000, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)3, 100, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)1, 1000, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)4, 1000, ProcessWakeupRequestPriority::pwrp_Critical);
 
     CHECK_EQUAL(4, testable.PublicMorozov_Get_requests_size());
     CHECK_EQUAL((void *)3, testable.PublicMorozov_Get_request(0).id);
@@ -103,7 +103,7 @@ TEST(ProcessWakeupServiceTestsGroup, Requests_ordered_by_next_tick) {
     CHECK_EQUAL((void *)2, testable.PublicMorozov_Get_request(3).id);
 
     os_us = (uint32_t)INT32_MAX + 1000;
-    testable.Request((void *)5, 50, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)5, 50, ProcessWakeupRequestPriority::pwrp_Critical);
 
     CHECK_EQUAL(5, testable.PublicMorozov_Get_requests_size());
     CHECK_EQUAL((void *)3, testable.PublicMorozov_Get_request(0).id);
@@ -116,13 +116,13 @@ TEST(ProcessWakeupServiceTestsGroup, Requests_ordered_by_next_tick) {
     CHECK_EQUAL(1, testable.PublicMorozov_Get_requests_size());
 
     os_us = UINT32_MAX;
-    testable.Request((void *)6, 10, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)6, 10, ProcessWakeupRequestPriority::pwrp_Critical);
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
     CHECK_EQUAL((void *)5, testable.PublicMorozov_Get_request(0).id);
     CHECK_EQUAL((void *)6, testable.PublicMorozov_Get_request(1).id);
 
     os_us = 999;
-    testable.Request((void *)7, 10, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)7, 10, ProcessWakeupRequestPriority::pwrp_Critical);
     CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
     CHECK_EQUAL((void *)5, testable.PublicMorozov_Get_request(0).id);
     CHECK_EQUAL((void *)6, testable.PublicMorozov_Get_request(1).id);
@@ -137,9 +137,9 @@ TEST(ProcessWakeupServiceTestsGroup, RemoveRequest) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)2, 20, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)3, 30, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)2, 20, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)3, 30, ProcessWakeupRequestPriority::pwrp_Critical);
     CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
     CHECK_EQUAL((void *)1, testable.PublicMorozov_Get_request(0).id);
     CHECK_EQUAL((void *)2, testable.PublicMorozov_Get_request(1).id);
@@ -166,9 +166,9 @@ TEST(ProcessWakeupServiceTestsGroup, Remove_not_exists_request) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)2, 20, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)3, 30, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)2, 20, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)3, 30, ProcessWakeupRequestPriority::pwrp_Critical);
     CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
 
     testable.RemoveRequest((void *)4);
@@ -186,11 +186,11 @@ TEST(ProcessWakeupServiceTestsGroup, Get_returns_early_tick) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 200, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)2, 1000, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)3, 300, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)4, 40, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)5, 400, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)1, 200, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)2, 1000, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)3, 300, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)4, 40, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)5, 400, ProcessWakeupRequestPriority::pwrp_Critical);
 
     auto ticksToWait = testable.Get();
     CHECK_EQUAL(4, ticksToWait);
@@ -214,32 +214,32 @@ TEST(ProcessWakeupServiceTestsGroup, Requested_round_ticks_to_up) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 215, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)1, 215, ProcessWakeupRequestPriority::pwrp_Critical);
     auto ticksToWait = testable.Get();
     CHECK_EQUAL(22, ticksToWait);
     CHECK_EQUAL(1, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)2, 210, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)2, 210, ProcessWakeupRequestPriority::pwrp_Critical);
     ticksToWait = testable.Get();
     CHECK_EQUAL(21, ticksToWait);
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)3, 209, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)3, 209, ProcessWakeupRequestPriority::pwrp_Critical);
     ticksToWait = testable.Get();
     CHECK_EQUAL(21, ticksToWait);
     CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)4, 205, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)4, 205, ProcessWakeupRequestPriority::pwrp_Critical);
     ticksToWait = testable.Get();
     CHECK_EQUAL(21, ticksToWait);
     CHECK_EQUAL(4, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)5, 201, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)5, 201, ProcessWakeupRequestPriority::pwrp_Critical);
     ticksToWait = testable.Get();
     CHECK_EQUAL(20, ticksToWait);
     CHECK_EQUAL(5, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)6, 200, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)6, 200, ProcessWakeupRequestPriority::pwrp_Critical);
     ticksToWait = testable.Get();
     CHECK_EQUAL(20, ticksToWait);
     CHECK_EQUAL(6, testable.PublicMorozov_Get_requests_size());
@@ -253,7 +253,7 @@ TEST(ProcessWakeupServiceTestsGroup, Request_zero) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request(NULL, 0, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request(NULL, 0, ProcessWakeupRequestPriority::pwrp_Critical);
     os_us = 51616;
     auto ticksToWait = testable.Get();
     CHECK_EQUAL(0, ticksToWait);
@@ -267,8 +267,8 @@ TEST(ProcessWakeupServiceTestsGroup, RemoveExpired) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 100, ProcessWakeupRequestPriority::pwrp_Normal);
-    testable.Request((void *)2, 200, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)1, 100, ProcessWakeupRequestPriority::pwrp_Critical);
+    testable.Request((void *)2, 200, ProcessWakeupRequestPriority::pwrp_Critical);
     testable.println();
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
 
@@ -324,4 +324,31 @@ TEST(ProcessWakeupServiceTestsGroup, GetTimespan) {
 
     timespan = ProcessWakeupRequestDataCmp::GetTimespan(0, UINT64_MAX);
     CHECK_EQUAL(-1, timespan);
+}
+
+TEST(ProcessWakeupServiceTestsGroup, Idle_requests_can_be_joined_next_time_if_soon) {
+    volatile uint64_t os_us = 0;
+    mock()
+        .expectNCalls(6, "esp_timer_get_time")
+        .withOutputParameterReturning("os_us", (const void *)&os_us, sizeof(os_us));
+
+    TestableProcessWakeupService testable;
+
+    CHECK_TRUE(testable.Request((void *)1, 100, ProcessWakeupRequestPriority::pwrp_Critical));
+    CHECK_TRUE(testable.Request((void *)2, 200, ProcessWakeupRequestPriority::pwrp_Critical));
+
+    CHECK_TRUE(testable.Request((void *)30, 0, ProcessWakeupRequestPriority::pwrp_Idle));
+    CHECK_EQUAL((void *)30, testable.PublicMorozov_Get_request(0).id);
+    CHECK_EQUAL(0, testable.PublicMorozov_Get_request(0).next_time);
+
+    CHECK_TRUE(testable.Request((void *)31, 1, ProcessWakeupRequestPriority::pwrp_Idle));
+    CHECK_EQUAL((void *)31, testable.PublicMorozov_Get_request(2).id);
+    CHECK_EQUAL(100 * 1000, testable.PublicMorozov_Get_request(2).next_time);
+
+    os_us = 10 * 1000;
+    testable.RemoveExpired();
+    CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
+    os_us = 100 * 1000;
+    testable.RemoveExpired();
+    CHECK_EQUAL(1, testable.PublicMorozov_Get_requests_size());
 }

--- a/Tests_esp8266/src/logic_ProcessWakeupService_tests.cpp
+++ b/Tests_esp8266/src/logic_ProcessWakeupService_tests.cpp
@@ -53,18 +53,18 @@ TEST(ProcessWakeupServiceTestsGroup, Requests_are_unique_by_id) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 10);
+    testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Normal);
     CHECK_EQUAL(1, testable.PublicMorozov_Get_requests_size());
-    testable.Request((void *)2, 20);
+    testable.Request((void *)2, 20, ProcessWakeupRequestPriority::pwrp_Normal);
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
-    testable.Request((void *)1, 11);
+    testable.Request((void *)1, 11, ProcessWakeupRequestPriority::pwrp_Normal);
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
-    testable.Request((void *)2, 21);
+    testable.Request((void *)2, 21, ProcessWakeupRequestPriority::pwrp_Normal);
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)3, 10);
+    testable.Request((void *)3, 10, ProcessWakeupRequestPriority::pwrp_Normal);
     CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
-    testable.Request((void *)4, 20);
+    testable.Request((void *)4, 20, ProcessWakeupRequestPriority::pwrp_Normal);
     CHECK_EQUAL(4, testable.PublicMorozov_Get_requests_size());
 }
 
@@ -76,10 +76,10 @@ TEST(ProcessWakeupServiceTestsGroup, Requests_returns_true_if_successfully_added
 
     TestableProcessWakeupService testable;
 
-    CHECK_TRUE(testable.Request((void *)1, 10));
-    CHECK_FALSE(testable.Request((void *)1, 11));
-    CHECK_TRUE(testable.Request((void *)2, 10));
-    CHECK_FALSE(testable.Request((void *)2, 11));
+    CHECK_TRUE(testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Normal));
+    CHECK_FALSE(testable.Request((void *)1, 11, ProcessWakeupRequestPriority::pwrp_Normal));
+    CHECK_TRUE(testable.Request((void *)2, 10, ProcessWakeupRequestPriority::pwrp_Normal));
+    CHECK_FALSE(testable.Request((void *)2, 11, ProcessWakeupRequestPriority::pwrp_Normal));
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
 }
 
@@ -91,10 +91,10 @@ TEST(ProcessWakeupServiceTestsGroup, Requests_ordered_by_next_tick) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)2, 2000);
-    testable.Request((void *)3, 100);
-    testable.Request((void *)1, 1000);
-    testable.Request((void *)4, 1000);
+    testable.Request((void *)2, 2000, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)3, 100, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)1, 1000, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)4, 1000, ProcessWakeupRequestPriority::pwrp_Normal);
 
     CHECK_EQUAL(4, testable.PublicMorozov_Get_requests_size());
     CHECK_EQUAL((void *)3, testable.PublicMorozov_Get_request(0).id);
@@ -103,7 +103,7 @@ TEST(ProcessWakeupServiceTestsGroup, Requests_ordered_by_next_tick) {
     CHECK_EQUAL((void *)2, testable.PublicMorozov_Get_request(3).id);
 
     os_us = (uint32_t)INT32_MAX + 1000;
-    testable.Request((void *)5, 50);
+    testable.Request((void *)5, 50, ProcessWakeupRequestPriority::pwrp_Normal);
 
     CHECK_EQUAL(5, testable.PublicMorozov_Get_requests_size());
     CHECK_EQUAL((void *)3, testable.PublicMorozov_Get_request(0).id);
@@ -116,13 +116,13 @@ TEST(ProcessWakeupServiceTestsGroup, Requests_ordered_by_next_tick) {
     CHECK_EQUAL(1, testable.PublicMorozov_Get_requests_size());
 
     os_us = UINT32_MAX;
-    testable.Request((void *)6, 10);
+    testable.Request((void *)6, 10, ProcessWakeupRequestPriority::pwrp_Normal);
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
     CHECK_EQUAL((void *)5, testable.PublicMorozov_Get_request(0).id);
     CHECK_EQUAL((void *)6, testable.PublicMorozov_Get_request(1).id);
 
     os_us = 999;
-    testable.Request((void *)7, 10);
+    testable.Request((void *)7, 10, ProcessWakeupRequestPriority::pwrp_Normal);
     CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
     CHECK_EQUAL((void *)5, testable.PublicMorozov_Get_request(0).id);
     CHECK_EQUAL((void *)6, testable.PublicMorozov_Get_request(1).id);
@@ -137,9 +137,9 @@ TEST(ProcessWakeupServiceTestsGroup, RemoveRequest) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 10);
-    testable.Request((void *)2, 20);
-    testable.Request((void *)3, 30);
+    testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)2, 20, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)3, 30, ProcessWakeupRequestPriority::pwrp_Normal);
     CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
     CHECK_EQUAL((void *)1, testable.PublicMorozov_Get_request(0).id);
     CHECK_EQUAL((void *)2, testable.PublicMorozov_Get_request(1).id);
@@ -166,9 +166,9 @@ TEST(ProcessWakeupServiceTestsGroup, Remove_not_exists_request) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 10);
-    testable.Request((void *)2, 20);
-    testable.Request((void *)3, 30);
+    testable.Request((void *)1, 10, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)2, 20, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)3, 30, ProcessWakeupRequestPriority::pwrp_Normal);
     CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
 
     testable.RemoveRequest((void *)4);
@@ -186,11 +186,11 @@ TEST(ProcessWakeupServiceTestsGroup, Get_returns_early_tick) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 200);
-    testable.Request((void *)2, 1000);
-    testable.Request((void *)3, 300);
-    testable.Request((void *)4, 40);
-    testable.Request((void *)5, 400);
+    testable.Request((void *)1, 200, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)2, 1000, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)3, 300, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)4, 40, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)5, 400, ProcessWakeupRequestPriority::pwrp_Normal);
 
     auto ticksToWait = testable.Get();
     CHECK_EQUAL(4, ticksToWait);
@@ -214,32 +214,32 @@ TEST(ProcessWakeupServiceTestsGroup, Requested_round_ticks_to_up) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 215);
+    testable.Request((void *)1, 215, ProcessWakeupRequestPriority::pwrp_Normal);
     auto ticksToWait = testable.Get();
     CHECK_EQUAL(22, ticksToWait);
     CHECK_EQUAL(1, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)2, 210);
+    testable.Request((void *)2, 210, ProcessWakeupRequestPriority::pwrp_Normal);
     ticksToWait = testable.Get();
     CHECK_EQUAL(21, ticksToWait);
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)3, 209);
+    testable.Request((void *)3, 209, ProcessWakeupRequestPriority::pwrp_Normal);
     ticksToWait = testable.Get();
     CHECK_EQUAL(21, ticksToWait);
     CHECK_EQUAL(3, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)4, 205);
+    testable.Request((void *)4, 205, ProcessWakeupRequestPriority::pwrp_Normal);
     ticksToWait = testable.Get();
     CHECK_EQUAL(21, ticksToWait);
     CHECK_EQUAL(4, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)5, 201);
+    testable.Request((void *)5, 201, ProcessWakeupRequestPriority::pwrp_Normal);
     ticksToWait = testable.Get();
     CHECK_EQUAL(20, ticksToWait);
     CHECK_EQUAL(5, testable.PublicMorozov_Get_requests_size());
 
-    testable.Request((void *)6, 200);
+    testable.Request((void *)6, 200, ProcessWakeupRequestPriority::pwrp_Normal);
     ticksToWait = testable.Get();
     CHECK_EQUAL(20, ticksToWait);
     CHECK_EQUAL(6, testable.PublicMorozov_Get_requests_size());
@@ -253,7 +253,7 @@ TEST(ProcessWakeupServiceTestsGroup, Request_zero) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request(NULL, 0);
+    testable.Request(NULL, 0, ProcessWakeupRequestPriority::pwrp_Normal);
     os_us = 51616;
     auto ticksToWait = testable.Get();
     CHECK_EQUAL(0, ticksToWait);
@@ -267,8 +267,8 @@ TEST(ProcessWakeupServiceTestsGroup, RemoveExpired) {
 
     TestableProcessWakeupService testable;
 
-    testable.Request((void *)1, 100);
-    testable.Request((void *)2, 200);
+    testable.Request((void *)1, 100, ProcessWakeupRequestPriority::pwrp_Normal);
+    testable.Request((void *)2, 200, ProcessWakeupRequestPriority::pwrp_Normal);
     testable.println();
     CHECK_EQUAL(2, testable.PublicMorozov_Get_requests_size());
 


### PR DESCRIPTION
implement #34.
У запросов с низким приоритетом время пробуждения может быть заменено на время пробуждения следующего запроса, если разница во времени менее 100мс.
Для Indicator и ControllerAI установлены низкие приоритеты