### PR TITLE
fix segfault when CommonOutput::Output is null. Output elements must …

### DIFF
--- a/PLC_esp8266/main/LogicProgram/ElementsBox.cpp
+++ b/PLC_esp8266/main/LogicProgram/ElementsBox.cpp
@@ -114,6 +114,22 @@ void ElementsBox::CopyParamsToInputElement(LogicElement *source_element, InputEl
     input->SetIoAdr(io_adr);
 }
 
+bool ElementsBox::CopyParamsToCommonOutputElement(LogicElement *source_element,
+                                                  CommonOutput *common_output) {
+    if (common_output == NULL) {
+        return false;
+    }
+    MapIO io_adr = MapIO::V1;
+
+    auto *source_element_as_output = CommonOutput::TryToCast(source_element);
+    if (source_element_as_output != NULL) {
+        io_adr = source_element_as_output->GetIoAdr();
+    }
+
+    common_output->SetIoAdr(io_adr);
+    return true;
+}
+
 bool ElementsBox::CopyParamsToCommonComparator(LogicElement *source_element,
                                                CommonComparator *common_comparator) {
     if (common_comparator == NULL) {
@@ -231,6 +247,9 @@ void ElementsBox::TakeParamsFromStoredElement(LogicElement *source_element,
 
     CopyParamsToInputElement(source_element, InputElement::TryToCast(new_element));
 
+    if (CopyParamsToCommonOutputElement(source_element, CommonOutput::TryToCast(new_element))) {
+        return;
+    }
     if (CopyParamsToCommonComparator(source_element, CommonComparator::TryToCast(new_element))) {
         return;
     }

--- a/PLC_esp8266/main/LogicProgram/ElementsBox.h
+++ b/PLC_esp8266/main/LogicProgram/ElementsBox.h
@@ -28,6 +28,7 @@ class ElementsBox : public LogicElement, public std::vector<LogicElement *> {
                                TvElementType element_type,
                                uint8_t *frame_buffer);
     void CopyParamsToInputElement(LogicElement *source_element, InputElement *input);
+    bool CopyParamsToCommonOutputElement(LogicElement *source_element, CommonOutput *common_output);
     bool CopyParamsToCommonComparator(LogicElement *source_element,
                                       CommonComparator *common_comparator);
     bool CopyParamsToCommonTimer(LogicElement *source_element, CommonTimer *common_timer);

--- a/PLC_esp8266/main/LogicProgram/InputElement.cpp
+++ b/PLC_esp8266/main/LogicProgram/InputElement.cpp
@@ -1,7 +1,7 @@
 #include "LogicProgram/InputElement.h"
+#include "LogicProgram/Bindings/WiFiApBinding.h"
 #include "LogicProgram/Bindings/WiFiBinding.h"
 #include "LogicProgram/Bindings/WiFiStaBinding.h"
-#include "LogicProgram/Bindings/WiFiApBinding.h"
 #include "LogicProgram/ControllerAI.h"
 #include "LogicProgram/ControllerDI.h"
 #include "LogicProgram/Inputs/CommonComparator.h"
@@ -106,15 +106,8 @@ InputElement *InputElement::TryToCast(LogicElement *logic_element) {
         case TvElementType::et_WiFiStaBinding:
             return static_cast<WiFiStaBinding *>(logic_element);
 
-            case TvElementType::et_WiFiApBinding:
-                return static_cast<WiFiApBinding *>(logic_element);
-
-        case TvElementType::et_DirectOutput:
-        case TvElementType::et_SetOutput:
-        case TvElementType::et_ResetOutput:
-        case TvElementType::et_IncOutput:
-        case TvElementType::et_DecOutput:
-            return static_cast<CommonOutput *>(logic_element);
+        case TvElementType::et_WiFiApBinding:
+            return static_cast<WiFiApBinding *>(logic_element);
 
         default:
             return NULL;

--- a/Tests_esp8266/src/logic_ElementsBox_tests.cpp
+++ b/Tests_esp8266/src/logic_ElementsBox_tests.cpp
@@ -537,3 +537,17 @@ TEST(LogicElementsBoxTestsGroup, SelectNext_on_WiFiStaBinding_calls_DetachElemen
 
     delete testable.GetSelectedElement();
 }
+
+TEST(LogicElementsBoxTestsGroup, output_elements_will_not_accept_address_which_is_only_for_inputs) {
+    int matched = 0;
+    Indicator stored_element(MapIO::AI);
+    ElementsBox testable(100, &stored_element, false);
+    for (auto *element : testable) {
+        auto *element_as_commonOutput = CommonOutput::TryToCast(element);
+        if (element_as_commonOutput != NULL) {
+            CHECK_EQUAL(MapIO::V1, element_as_commonOutput->GetIoAdr());
+            matched++;
+        }
+    }
+    CHECK_EQUAL(5, matched);
+}

--- a/Tests_esp8266/src/logic_InputElement_tests.cpp
+++ b/Tests_esp8266/src/logic_InputElement_tests.cpp
@@ -33,47 +33,47 @@ TEST_GROUP(LogicInputElementTestsGroup){ //
 
 TEST(LogicInputElementTestsGroup, TryToCast) {
     InputNC inputNC;
-    CHECK_TRUE(InputElement::TryToCast(&inputNC) == &inputNC);
+    CHECK(InputElement::TryToCast(&inputNC) == &inputNC);
 
     InputNO inputNO;
-    CHECK_TRUE(InputElement::TryToCast(&inputNO) == &inputNO);
+    CHECK(InputElement::TryToCast(&inputNO) == &inputNO);
 
     ComparatorEq comparatorEq;
-    CHECK_TRUE(InputElement::TryToCast(&comparatorEq) == &comparatorEq);
+    CHECK(InputElement::TryToCast(&comparatorEq) == &comparatorEq);
 
     ComparatorGE comparatorGE;
-    CHECK_TRUE(InputElement::TryToCast(&comparatorGE) == &comparatorGE);
+    CHECK(InputElement::TryToCast(&comparatorGE) == &comparatorGE);
 
     ComparatorGr comparatorGr;
-    CHECK_TRUE(InputElement::TryToCast(&comparatorGr) == &comparatorGr);
+    CHECK(InputElement::TryToCast(&comparatorGr) == &comparatorGr);
 
     ComparatorLE comparatorLE;
-    CHECK_TRUE(InputElement::TryToCast(&comparatorLE) == &comparatorLE);
+    CHECK(InputElement::TryToCast(&comparatorLE) == &comparatorLE);
 
     ComparatorLs comparatorLs;
-    CHECK_TRUE(InputElement::TryToCast(&comparatorLs) == &comparatorLs);
+    CHECK(InputElement::TryToCast(&comparatorLs) == &comparatorLs);
 
     TimerMSecs timerMSecs;
-    CHECK_TRUE(InputElement::TryToCast(&timerMSecs) == NULL);
+    CHECK(InputElement::TryToCast(&timerMSecs) == NULL);
 
     TimerSecs timerSecs;
-    CHECK_TRUE(InputElement::TryToCast(&timerSecs) == NULL);
+    CHECK(InputElement::TryToCast(&timerSecs) == NULL);
 
     DirectOutput directOutput;
-    CHECK_TRUE(InputElement::TryToCast(&directOutput) == &directOutput);
+    CHECK(InputElement::TryToCast(&directOutput) == NULL);
 
     SetOutput setOutput;
-    CHECK_TRUE(InputElement::TryToCast(&setOutput) == &setOutput);
+    CHECK(InputElement::TryToCast(&setOutput) == NULL);
 
     ResetOutput resetOutput;
-    CHECK_TRUE(InputElement::TryToCast(&resetOutput) == &resetOutput);
+    CHECK(InputElement::TryToCast(&resetOutput) == NULL);
 
     IncOutput incOutput;
-    CHECK_TRUE(InputElement::TryToCast(&incOutput) == &incOutput);
+    CHECK(InputElement::TryToCast(&incOutput) == NULL);
 
     DecOutput decOutput;
-    CHECK_TRUE(InputElement::TryToCast(&decOutput) == &decOutput);
+    CHECK(InputElement::TryToCast(&decOutput) == NULL);
 
     WiFiBinding wiFiBinding;
-    CHECK_TRUE(InputElement::TryToCast(&wiFiBinding) == &wiFiBinding);
+    CHECK(InputElement::TryToCast(&wiFiBinding) == &wiFiBinding);
 }


### PR DESCRIPTION
…not accept an address that is only intended for inputs.