### PR TITLE
WiFiService: fix potential error "error: 'void* memcpy(void*, const v…

### DIFF
--- a/PLC_esp8266/main/WiFi/WiFiService_AccessPoint.cpp
+++ b/PLC_esp8266/main/WiFi/WiFiService_AccessPoint.cpp
@@ -141,7 +141,7 @@ void WiFiService::ap_connect_wifi_event_handler(void *arg,
 
     if (WiFiApBinding::ClientMacMatches(ap_event_arg->mac, event->mac)) {
         t_mac mac = {};
-        memcpy(&mac, &event->mac, sizeof(event->mac));
+        memcpy(&mac, event->mac, sizeof(event->mac));
         ap_event_arg->service->AddApClient(ap_event_arg->ssid, mac);
         Controller::WakeupProcessTask();
     } else {
@@ -166,7 +166,7 @@ void WiFiService::ap_disconnect_wifi_event_handler(void *arg,
 
     if (WiFiApBinding::ClientMacMatches(ap_event_arg->mac, event->mac)) {
         t_mac mac = {};
-        memcpy(&mac, &event->mac, sizeof(event->mac));
+        memcpy(&mac, event->mac, sizeof(event->mac));
         ap_event_arg->service->RemoveApClient(ap_event_arg->ssid, mac);
         Controller::WakeupProcessTask();
     }


### PR DESCRIPTION
…oid*, size_t)' reading 6 bytes from a region of size 4 [-Werror=stringop-overflow=]"