### PR TITLE
Settings adc period

### DIFF
--- a/PLC_esp8266/main/DataMigrations/MigrateSettings.h
+++ b/PLC_esp8266/main/DataMigrations/MigrateSettings.h
@@ -4,6 +4,7 @@
 #include "Settings_20250107.h"
 #include "Settings_20250209.h"
 #include "Settings_20250413.h"
+#include "Settings_20250619.h"
 
 const TDataMigrate Migrate_Settings[] = {
     { INITIAL_VERSION, 0, 0, 0 },
@@ -11,6 +12,7 @@ const TDataMigrate Migrate_Settings[] = {
     MigrateSettings::v20250107::DataMigrate, //
     MigrateSettings::v20250209::DataMigrate, //
     MigrateSettings::v20250413::DataMigrate, //
+    MigrateSettings::v20250619::DataMigrate, //
 };
 
 const TDataMigrateItems SettingsMigrations = {
@@ -18,4 +20,4 @@ const TDataMigrateItems SettingsMigrations = {
     sizeof(Migrate_Settings) / sizeof(Migrate_Settings[0]) //
 };
 
-namespace CurrentSettings = MigrateSettings::v20250413::Snapshot;
+namespace CurrentSettings = MigrateSettings::v20250619::Snapshot;

--- a/PLC_esp8266/main/DataMigrations/Settings_20250619.h
+++ b/PLC_esp8266/main/DataMigrations/Settings_20250619.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "MigrateAnyData/MigrateAnyData.h"
+#include "esp_log.h"
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+namespace MigrateSettings {
+    namespace v20250619 {
+        inline int GetSizeOfCurrentData();
+        inline void MigrateUp(void *pCurr, void *pPrev);
+        inline void MigrateDown(void *pCurr, void *pPrev);
+
+        const TDataMigrate DataMigrate = { 0x20250619,
+                                           MigrateUp,
+                                           MigrateDown,
+                                           GetSizeOfCurrentData };
+
+        namespace Snapshot {
+            typedef struct {
+                uint32_t counter;
+            } smartconfig_settings;
+
+            typedef struct {
+                char ssid[32];
+                char password[64];
+                int32_t connect_max_retry_count;
+                uint32_t reconnect_delay_ms;
+                uint32_t scan_station_rssi_period_ms;
+                int8_t max_rssi;
+                int8_t min_rssi;
+                uint32_t min_worktime_ms;
+            } wifi_station_settings;
+
+            typedef struct {
+                uint16_t per_channel_scan_time_ms;
+                int8_t max_rssi;
+                int8_t min_rssi;
+            } wifi_scanner_settings;
+
+            typedef struct {
+                uint32_t generation_time_ms;
+                bool ssid_hidden;
+            } wifi_access_point_settings;
+
+            typedef struct {
+                char sntp_server_primary[64];
+                char sntp_server_secondary[64];
+                char timezone[32];
+            } datetime_settings;
+
+            typedef struct {
+                uint32_t scan_period_ms;
+            } adc_settings;
+
+            typedef struct {
+                smartconfig_settings smartconfig;
+                wifi_station_settings wifi_station;
+                wifi_scanner_settings wifi_scanner;
+                wifi_access_point_settings wifi_access_point;
+                datetime_settings datetime;
+                adc_settings adc;
+            } device_settings;
+        } // namespace Snapshot
+
+        inline int GetSizeOfCurrentData() {
+            return sizeof(Snapshot::device_settings);
+        }
+
+        inline void MigrateUp(void *pCurr, void *pPrev) {
+            auto pCurrSettings = (Snapshot::device_settings *)pCurr;
+            auto pPrevSettings = (v20250413::Snapshot::device_settings *)pPrev;
+
+            memcpy(&pCurrSettings->smartconfig,
+                   &pPrevSettings->smartconfig,
+                   sizeof(pPrevSettings->smartconfig));
+            memcpy(&pCurrSettings->wifi_station,
+                   &pPrevSettings->wifi_station,
+                   sizeof(pCurrSettings->wifi_station));
+            memcpy(&pCurrSettings->wifi_scanner,
+                   &pPrevSettings->wifi_scanner,
+                   sizeof(pCurrSettings->wifi_scanner));
+            memcpy(&pCurrSettings->wifi_access_point,
+                   &pPrevSettings->wifi_access_point,
+                   sizeof(pCurrSettings->wifi_access_point));
+
+            pCurrSettings->adc.scan_period_ms = 1000;
+
+            ESP_LOGI("Settings_20250619", "Migrate to %08X", (unsigned int)DataMigrate.Version);
+        }
+
+        inline void MigrateDown(void *pCurr, void *pPrev) {
+            auto pCurrSettings = (Snapshot::device_settings *)pCurr;
+            auto pPrevSettings = (v20250413::Snapshot::device_settings *)pPrev;
+
+            memcpy(&pPrevSettings->smartconfig,
+                   &pCurrSettings->smartconfig,
+                   sizeof(pPrevSettings->smartconfig));
+            memcpy(&pPrevSettings->wifi_station,
+                   &pCurrSettings->wifi_station,
+                   sizeof(pPrevSettings->wifi_station));
+            memcpy(&pPrevSettings->wifi_scanner,
+                   &pCurrSettings->wifi_scanner,
+                   sizeof(pPrevSettings->wifi_scanner));
+            memcpy(&pPrevSettings->wifi_access_point,
+                   &pCurrSettings->wifi_access_point,
+                   sizeof(pPrevSettings->wifi_access_point));
+        }
+
+    } // namespace v20250619
+} // namespace MigrateSettings

--- a/PLC_esp8266/main/LogicProgram/ControllerAI.cpp
+++ b/PLC_esp8266/main/LogicProgram/ControllerAI.cpp
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+extern CurrentSettings::device_settings settings;
+
 ControllerAI::ControllerAI() : ControllerBaseInput() {
 }
 
@@ -14,7 +16,7 @@ void ControllerAI::FetchValue() {
         return;
     }
     if (!Controller::RequestWakeupMs((void *)&Controller::AI,
-                                     read_adc_max_period_ms,
+                                     settings.adc.scan_period_ms,
                                      ProcessWakeupRequestPriority::pwrp_Idle)) {
         return;
     }

--- a/PLC_esp8266/main/LogicProgram/ControllerAI.cpp
+++ b/PLC_esp8266/main/LogicProgram/ControllerAI.cpp
@@ -2,9 +2,12 @@
 #include "LogicProgram/Controller.h"
 #include "LogicProgram/LogicElement.h"
 #include "sys_gpio.h"
+#include "esp_log.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+static const char *TAG_ControllerAI = "ControllerAI";
 
 extern CurrentSettings::device_settings settings;
 
@@ -25,4 +28,5 @@ void ControllerAI::FetchValue() {
     uint16_t val_10bit = get_analog_value();
     uint8_t percent04 = val_10bit / 4;
     UpdateValue(percent04);
+    ESP_LOGD(TAG_ControllerAI, "fetch value");
 }

--- a/PLC_esp8266/main/LogicProgram/ControllerAI.h
+++ b/PLC_esp8266/main/LogicProgram/ControllerAI.h
@@ -8,6 +8,5 @@ class ControllerAI : public ControllerBaseInput {
   protected:
   public:
     ControllerAI();
-    const int read_adc_max_period_ms = 1000;
     void FetchValue() override;
 };

--- a/PLC_esp8266/main/LogicProgram/Settings/SettingsElement.cpp
+++ b/PLC_esp8266/main/LogicProgram/Settings/SettingsElement.cpp
@@ -171,6 +171,9 @@ bool SettingsElement::RenderName(uint8_t *fb, uint8_t x, uint8_t y) {
         case t_datetime_timezone:
             name = "Timezone";
             break;
+        case t_adc_scan_period_ms:
+            name = "ADC: scan period, mS";
+            break;
         default:
             return false;
     }
@@ -292,6 +295,7 @@ bool SettingsElement::ValidateDiscriminator(Discriminator *discriminator) {
         case t_datetime_sntp_server_primary:
         case t_datetime_sntp_server_secondary:
         case t_datetime_timezone:
+        case t_adc_scan_period_ms:
             return true;
 
         default:
@@ -430,6 +434,10 @@ void SettingsElement::ReadValue(char *string_buffer, bool friendly_format) {
             string_buffer[max_len] = 0;
             break;
         }
+        case t_adc_scan_period_ms:
+            sprintf(string_buffer, "%u", (unsigned int)curr_settings.adc.scan_period_ms);
+            break;
+
         default:
             break;
     }
@@ -528,6 +536,9 @@ void SettingsElement::SelectPriorSymbol(char *symbol, bool first) {
         case t_datetime_timezone:
             SelectPriorStringSymbol(symbol);
             break;
+        case t_adc_scan_period_ms:
+            SelectPriorNumberSymbol(symbol, 0);
+            break;
 
         default:
             break;
@@ -576,7 +587,9 @@ void SettingsElement::SelectNextSymbol(char *symbol, bool first) {
         case t_datetime_timezone:
             SelectNextStringSymbol(symbol);
             break;
-
+        case t_adc_scan_period_ms:
+            SelectNextNumberSymbol(symbol, 0);
+            break;
         default:
             break;
     }
@@ -591,7 +604,7 @@ void SettingsElement::SelectPrior() {
         case SettingsElement::EditingPropertyId::cwbepi_SelectDiscriminator: {
             auto _discriminator = (Discriminator)(discriminator - 1);
             if (!ValidateDiscriminator(&_discriminator)) {
-                _discriminator = Discriminator::t_datetime_timezone;
+                _discriminator = Discriminator::t_adc_scan_period_ms;
             }
             discriminator = _discriminator;
             break;
@@ -778,6 +791,9 @@ void SettingsElement::EndEditing() {
             break;
         case t_datetime_timezone:
             WriteString(curr_settings.datetime.timezone, sizeof(curr_settings.datetime.timezone));
+            break;
+        case t_adc_scan_period_ms:
+            curr_settings.adc.scan_period_ms = atol(value);
             break;
         default:
             break;

--- a/PLC_esp8266/main/LogicProgram/Settings/SettingsElement.h
+++ b/PLC_esp8266/main/LogicProgram/Settings/SettingsElement.h
@@ -32,6 +32,7 @@ class SettingsElement : public LogicElement {
         t_datetime_sntp_server_primary,
         t_datetime_sntp_server_secondary,
         t_datetime_timezone,
+        t_adc_scan_period_ms,
     } Discriminator;
 
   protected:

--- a/PLC_esp8266/main/component.mk
+++ b/PLC_esp8266/main/component.mk
@@ -10,7 +10,7 @@ COMPONENT_SRCDIRS := . MigrateAnyData HttpServer Display Display/ssd1306 Display
 
 
 #use for main/settings.cpp
-DEVICE_VERSION:=20250413
+DEVICE_VERSION:=20250619
 DEVICE_VERSION_seconds:=$(shell date -d '$(DEVICE_VERSION)' +'%s')
 current_seconds:=$(shell date +'%s')
 minutes_since=$(shell echo "($(current_seconds) - $(DEVICE_VERSION_seconds)) / 60" | bc)

--- a/PLC_esp8266/main/settings.cpp
+++ b/PLC_esp8266/main/settings.cpp
@@ -208,6 +208,12 @@ bool validate_settings(CurrentSettings::device_settings *settings) {
                  (unsigned int)settings->wifi_access_point.ssid_hidden);
         return false;
     }
+    if (invalid_uint(settings->adc.scan_period_ms, 20, 60 * 1000)) {
+        ESP_LOGI(TAG_settings,
+                 "Invalid adc.scan_period_ms, '%u'",
+                 (unsigned int)settings->adc.scan_period_ms);
+        return false;
+    }
     return true;
 }
 

--- a/Tests_esp8266/src/logic_SettingsElement_tests.cpp
+++ b/Tests_esp8266/src/logic_SettingsElement_tests.cpp
@@ -1004,7 +1004,7 @@ TEST(LogicSettingsElementTestsGroup, SelectNext_change_discriminator) {
                 *testable.PublicMorozov_Get_discriminator());
 
     testable.SelectNext();
-    CHECK_EQUAL(SettingsElement::Discriminator::t_wifi_station_settings_ssid,
+    CHECK_EQUAL(SettingsElement::Discriminator::t_adc_scan_period_ms,
                 *testable.PublicMorozov_Get_discriminator());
 }
 

--- a/Tests_esp8266/src/logic_SettingsElement_tests.cpp
+++ b/Tests_esp8266/src/logic_SettingsElement_tests.cpp
@@ -146,7 +146,7 @@ TEST(LogicSettingsElementTestsGroup, ValidateDiscriminator) {
 
     discriminator = (SettingsElement::Discriminator)-1;
     CHECK_FALSE(testable.PublicMorozov_ValidateDiscriminator(&discriminator));
-    discriminator = (SettingsElement::Discriminator)18;
+    discriminator = (SettingsElement::Discriminator)19;
     CHECK_FALSE(testable.PublicMorozov_ValidateDiscriminator(&discriminator));
     discriminator = (SettingsElement::Discriminator)100;
     CHECK_FALSE(testable.PublicMorozov_ValidateDiscriminator(&discriminator));
@@ -223,7 +223,7 @@ TEST(LogicSettingsElementTestsGroup, Deserialize_with_wrong_discriminator) {
     CHECK_EQUAL(0, readed);
 
     *((SettingsElement::Discriminator *)&buffer[1]) =
-        (SettingsElement::Discriminator)(SettingsElement::Discriminator::t_datetime_timezone + 1);
+        (SettingsElement::Discriminator)(SettingsElement::Discriminator::t_adc_scan_period_ms + 1);
     readed = testable.Deserialize(&buffer[1], sizeof(buffer) - 1);
     CHECK_EQUAL(0, readed);
 }
@@ -777,6 +777,9 @@ TEST(LogicSettingsElementTestsGroup, SelectPrior_change_discriminator) {
     CHECK_EQUAL(SettingsElement::Discriminator::t_wifi_station_settings_ssid,
                 *testable.PublicMorozov_Get_discriminator());
 
+    testable.SelectPrior();
+    CHECK_EQUAL(SettingsElement::Discriminator::t_adc_scan_period_ms,
+                *testable.PublicMorozov_Get_discriminator());
     testable.SelectPrior();
     CHECK_EQUAL(SettingsElement::Discriminator::t_datetime_timezone,
                 *testable.PublicMorozov_Get_discriminator());

--- a/Tests_esp8266/src/settings_tests.cpp
+++ b/Tests_esp8266/src/settings_tests.cpp
@@ -223,4 +223,13 @@ TEST(SettingsTestsGroup, validate_settings) {
     CHECK_TRUE(validate_settings(&settings));
     *((char *)&settings.wifi_access_point.ssid_hidden) = 1;
     CHECK_TRUE(validate_settings(&settings));
+
+    settings.adc.scan_period_ms = 19;
+    CHECK_FALSE(validate_settings(&settings));
+    settings.adc.scan_period_ms = 60001;
+    CHECK_FALSE(validate_settings(&settings));
+    settings.adc.scan_period_ms = 20;
+    CHECK_TRUE(validate_settings(&settings));
+    settings.adc.scan_period_ms = 60000;
+    CHECK_TRUE(validate_settings(&settings));
 }


### PR DESCRIPTION
Close #79 
Добавлена настройка:
- adc.scan_period_ms
- "ADC: scan period, mS"
- диапазон валидных значений: 20-60000mS