### PR TITLE
Rendering events in design

### DIFF
--- a/PLC_esp8266/main/LogicProgram/Controller.cpp
+++ b/PLC_esp8266/main/LogicProgram/Controller.cpp
@@ -421,7 +421,6 @@ void Controller::UpdateUIViewTop(int32_t view_top_index) {
         store_hotreload();
     });
     ESP_LOGD(TAG_Controller, "UpdateUIViewTop %d", view_top_index);
-    Controller::force_process_loop = true;
     Controller::WakeupProcessTask();
 }
 
@@ -431,10 +430,19 @@ void Controller::UpdateUISelected(int32_t selected_network) {
         store_hotreload();
     });
     ESP_LOGD(TAG_Controller, "UpdateUISelected %d", selected_network);
-    Controller::force_process_loop = true;
-    Controller::WakeupProcessTask();
 }
 
 int32_t Controller::GetLastUpdatedUISelected() {
     return hotreload->selected_network;
+}
+
+void Controller::DesignStart() {
+    Controller::force_process_loop = true;
+    Controller::WakeupProcessTask();
+    ESP_LOGI(TAG_Controller, "DesignStart");
+}
+
+void Controller::DesignEnd() {
+    Controller::force_process_loop = false;
+    ESP_LOGI(TAG_Controller, "DesignEnd");
 }

--- a/PLC_esp8266/main/LogicProgram/Controller.cpp
+++ b/PLC_esp8266/main/LogicProgram/Controller.cpp
@@ -34,7 +34,7 @@ static_assert((Controller::WAKEUP_PROCESS_TASK & GPIO_EVENTS_ALL_BITS) == 0,
 extern CurrentSettings::device_settings settings;
 
 bool Controller::runned = false;
-bool Controller::force_process_loop = false;
+bool Controller::in_design = false;
 EventGroupHandle_t Controller::gpio_events = NULL;
 TaskHandle_t Controller::process_task_handle = NULL;
 
@@ -191,8 +191,8 @@ void Controller::ProcessTask(void *parm) {
                                         loop_break_ms,
                                         ProcessWakeupRequestPriority::pwrp_Critical);
         } else {
-            if (Controller::force_process_loop) {
-                ESP_LOGD(TAG_Controller, "force_process_loop");
+            if (Controller::in_design) {
+                ESP_LOGD(TAG_Controller, "in_design");
                 const uint32_t process_loop_cycle_ms = 200;
                 Controller::RequestWakeupMs((void *)Controller::ProcessTask,
                                             process_loop_cycle_ms,
@@ -200,7 +200,7 @@ void Controller::ProcessTask(void *parm) {
             }
         }
 
-        if (do_render || Controller::force_process_loop) {
+        if (do_render || Controller::in_design) {
             rendering_service->Do();
         }
     }
@@ -437,12 +437,16 @@ int32_t Controller::GetLastUpdatedUISelected() {
 }
 
 void Controller::DesignStart() {
-    Controller::force_process_loop = true;
+    Controller::in_design = true;
     Controller::WakeupProcessTask();
     ESP_LOGI(TAG_Controller, "DesignStart");
 }
 
 void Controller::DesignEnd() {
-    Controller::force_process_loop = false;
+    Controller::in_design = false;
     ESP_LOGI(TAG_Controller, "DesignEnd");
+}
+
+bool Controller::InDesign() {
+    return Controller::in_design;
 }

--- a/PLC_esp8266/main/LogicProgram/Controller.h
+++ b/PLC_esp8266/main/LogicProgram/Controller.h
@@ -92,5 +92,7 @@ class Controller {
 
     static void UpdateUIViewTop(int32_t view_top_index);
     static void UpdateUISelected(int32_t selected_network);
+    static void DesignStart();
+    static void DesignEnd();
     static int32_t GetLastUpdatedUISelected();
 };

--- a/PLC_esp8266/main/LogicProgram/Controller.h
+++ b/PLC_esp8266/main/LogicProgram/Controller.h
@@ -33,7 +33,7 @@ class DatetimeService;
 class Controller {
   protected:
     static bool runned;
-    static bool force_process_loop;
+    static bool in_design;
     static EventGroupHandle_t gpio_events;
     static TaskHandle_t process_task_handle;
     static ProcessWakeupService *processWakeupService;
@@ -94,5 +94,6 @@ class Controller {
     static void UpdateUISelected(int32_t selected_network);
     static void DesignStart();
     static void DesignEnd();
+    static bool InDesign();
     static int32_t GetLastUpdatedUISelected();
 };

--- a/PLC_esp8266/main/LogicProgram/Ladder.cpp
+++ b/PLC_esp8266/main/LogicProgram/Ladder.cpp
@@ -1,5 +1,6 @@
 #include "LogicProgram/Ladder.h"
 #include "Display/ScrollBar.h"
+#include "LogicProgram/Controller.h"
 #include "esp_attr.h"
 #include "esp_err.h"
 #include "esp_log.h"
@@ -115,6 +116,7 @@ void Ladder::SetSelectedNetworkIndex(int16_t index) {
     switch (design_state) {
         case EditableElement::ElementState::des_Regular:
             (*this)[index]->Select();
+            Controller::DesignStart();
             break;
 
         case EditableElement::ElementState::des_Selected:

--- a/PLC_esp8266/main/LogicProgram/Ladder.cpp
+++ b/PLC_esp8266/main/LogicProgram/Ladder.cpp
@@ -4,6 +4,7 @@
 #include "esp_attr.h"
 #include "esp_err.h"
 #include "esp_log.h"
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -91,7 +92,7 @@ void Ladder::Delete(int network_id) {
     delete network;
 }
 
-void Ladder::SetViewTopIndex(int16_t index) {
+void Ladder::SetViewTopIndex(int32_t index) {
     ESP_LOGI(TAG_Ladder, "SetViewTopIndex, index:%d", index);
     if (index < 0 || index + Ladder::MaxViewPortCount > size()) {
         return;
@@ -99,7 +100,7 @@ void Ladder::SetViewTopIndex(int16_t index) {
     view_top_index = index;
 }
 
-void Ladder::SetSelectedNetworkIndex(int16_t index) {
+void Ladder::SetSelectedNetworkIndex(int32_t index) {
     auto selected_network = GetSelectedNetwork();
     auto design_state = GetDesignState(selected_network);
 
@@ -112,6 +113,8 @@ void Ladder::SetSelectedNetworkIndex(int16_t index) {
     if (index < 0 || index >= (int)size()) {
         return;
     }
+
+    index = std::clamp(index, view_top_index, (view_top_index + (int)Ladder::MaxViewPortCount) - 1);
 
     switch (design_state) {
         case EditableElement::ElementState::des_Regular:

--- a/PLC_esp8266/main/LogicProgram/Ladder.h
+++ b/PLC_esp8266/main/LogicProgram/Ladder.h
@@ -54,6 +54,6 @@ class Ladder : public std::vector<Network *> {
     void Store();
     static void DeleteStorage();
 
-    void SetViewTopIndex(int16_t index);
-    void SetSelectedNetworkIndex(int16_t index);
+    void SetViewTopIndex(int32_t index);
+    void SetSelectedNetworkIndex(int32_t index);
 };

--- a/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
+++ b/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
@@ -296,12 +296,11 @@ void Ladder::HandleButtonSelect() {
 
             if (last_selected_network >= 0 && last_selected_network < (int)size()) {
                 (*this)[last_selected_network]->Select();
-                break;
+            } else {
+                (*this)[view_top_index]->Select();
+                Controller::UpdateUISelected(view_top_index);
             }
-
-            (*this)[view_top_index]->Select();
-            Controller::UpdateUISelected(view_top_index);
-
+            Controller::DesignStart();
             break;
         }
 
@@ -319,6 +318,7 @@ void Ladder::HandleButtonSelect() {
                 Store();
                 Controller::UpdateUISelected(selected_network);
             }
+            Controller::DesignEnd();
             return;
 
         case EditableElement::ElementState::des_AdvancedSelectMove:

--- a/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
+++ b/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
@@ -432,14 +432,39 @@ TEST(LogicLadderDesignerTestsGroup, SetSelectedNetworkIndex_when_no_preselected)
     testable.Append(network2);
     testable.Append(network3);
 
+    testable.SetViewTopIndex(0);
     testable.SetSelectedNetworkIndex(1);
     CHECK_EQUAL(1, testable.PublicMorozov_GetSelectedNetwork());
     CHECK_TRUE(network1->Selected());
 
+    testable.SetViewTopIndex(2);
     testable.SetSelectedNetworkIndex(3);
     CHECK_EQUAL(3, testable.PublicMorozov_GetSelectedNetwork());
     CHECK_FALSE(network1->Selected());
     CHECK_TRUE(network3->Selected());
+}
+
+TEST(LogicLadderDesignerTestsGroup, SetSelectedNetworkIndex_limit_with_ViewTopIndex_range) {
+    TestableLadder testable;
+    auto network0 = new Network(LogicItemState::lisActive);
+    auto network1 = new Network(LogicItemState::lisActive);
+    auto network2 = new Network(LogicItemState::lisActive);
+    auto network3 = new Network(LogicItemState::lisActive);
+    testable.Append(network0);
+    testable.Append(network1);
+    testable.Append(network2);
+    testable.Append(network3);
+
+    testable.SetViewTopIndex(2);
+    testable.SetSelectedNetworkIndex(0);
+    CHECK_EQUAL(2, testable.PublicMorozov_GetSelectedNetwork());
+    CHECK_TRUE(network2->Selected());
+
+    testable.SetViewTopIndex(0);
+    testable.SetSelectedNetworkIndex(3);
+    CHECK_EQUAL(1, testable.PublicMorozov_GetSelectedNetwork());
+    CHECK_FALSE(network2->Selected());
+    CHECK_TRUE(network1->Selected());
 }
 
 TEST(LogicLadderDesignerTestsGroup, SetSelectedNetworkIndex_if_network_is_editing_then_do_nothing) {
@@ -563,6 +588,31 @@ TEST(LogicLadderDesignerTestsGroup, HandleButtonSelect_calls__Controller_UpdateU
     CHECK_EQUAL(0, hotreload->selected_network);
     CHECK_FALSE(testable[0]->Editing());
     CHECK_FALSE(testable[0]->Selected());
+}
+
+TEST(LogicLadderDesignerTestsGroup, HandleButtonSelect_calls__Controller_DesignStart) {
+    Controller::DesignEnd();
+    TestableLadder testable;
+
+    auto network0 = new Network(LogicItemState::lisActive);
+    network0->Append(new InputNC(MapIO::DI));
+    testable.Append(network0);
+    testable.Append(new Network(LogicItemState::lisActive));
+
+    CHECK_FALSE(Controller::InDesign());
+
+    testable.HandleButtonSelect();
+    CHECK_TRUE(testable[0]->Selected());
+    CHECK_TRUE(Controller::InDesign());
+
+    testable.HandleButtonSelect();
+    CHECK_TRUE(testable[0]->Editing());
+    CHECK_TRUE(Controller::InDesign());
+
+    testable.HandleButtonSelect();
+    CHECK_FALSE(testable[0]->Editing());
+    CHECK_FALSE(testable[0]->Selected());
+    CHECK_FALSE(Controller::InDesign());
 }
 
 TEST(LogicLadderDesignerTestsGroup, HandleButtonOption_enter_to_advanced_editing) {


### PR DESCRIPTION
Исправления состояния когда после scroll или перехода в режим дизайна, происходил "насильный" рендеринг каждые 200 мС.

Также исправлено восстановление после перезагрузки, ранее выделенного нетворка. Побочный эффект от восстановления выделения у нетворка после перезагрузки, это визуальная детекция непредвиденного ребута девайса