### PR TITLE
Refactor: Replace Inheritance with Composition for Collection Classes

### DIFF
--- a/PLC_esp8266/main/LogicProgram/Ladder.cpp
+++ b/PLC_esp8266/main/LogicProgram/Ladder.cpp
@@ -19,11 +19,23 @@ Ladder::~Ladder() {
     RemoveAll();
 }
 
+size_t Ladder::size() const {
+    return items.size();
+}
+
+Network *&Ladder::operator[](size_t index) {
+    return items[index];
+}
+
+Network *const &Ladder::operator[](size_t index) const {
+    return items[index];
+}
+
 void Ladder::RemoveAll() {
-    while (!empty()) {
-        auto it = begin();
+    while (!items.empty()) {
+        auto it = items.begin();
         auto network = *it;
-        erase(it);
+        items.erase(it);
         ESP_LOGD(TAG_Ladder, "delete network: %p", network);
         delete network;
     }
@@ -32,22 +44,22 @@ void Ladder::RemoveAll() {
 
 bool Ladder::DoAction() {
     bool any_changes = false;
-    for (auto it = begin(); it != end(); ++it) {
+    for (auto it = items.begin(); it != items.end(); ++it) {
         any_changes |= (*it)->DoAction();
     }
     return any_changes;
 }
 
 IRAM_ATTR void Ladder::Render(FrameBuffer *fb) {
-    for (size_t i = view_top_index; i < size(); i++) {
+    for (size_t i = view_top_index; i < items.size(); i++) {
         uint8_t network_number = i - view_top_index;
         if (network_number >= Ladder::MaxViewPortCount) {
             break;
         }
-        at(i)->Render(fb, i - view_top_index);
+        items.at(i)->Render(fb, i - view_top_index);
     }
 
-    ScrollBar::Render(fb, size(), Ladder::MaxViewPortCount, view_top_index);
+    ScrollBar::Render(fb, items.size(), Ladder::MaxViewPortCount, view_top_index);
 
     fb->has_changes |= frame_buffer_req_render || Controller::InDesign();
     frame_buffer_req_render = false;
@@ -55,28 +67,28 @@ IRAM_ATTR void Ladder::Render(FrameBuffer *fb) {
 
 void Ladder::Append(Network *network) {
     ESP_LOGD(TAG_Ladder, "append network: %p", network);
-    push_back(network);
+    items.push_back(network);
     frame_buffer_req_render = true;
 }
 
 void Ladder::Duplicate(int network_id) {
     ESP_LOGD(TAG_Ladder, "duplicate network id: %d", network_id);
 
-    size_t size = (*this)[network_id]->Serialize(NULL, 0);
-    if (size == 0) {
+    size_t buf_size = items[network_id]->Serialize(NULL, 0);
+    if (buf_size == 0) {
         ESP_LOGE(TAG_Ladder, "Duplicate error");
         return;
     }
-    uint8_t *data = new uint8_t[size];
+    uint8_t *data = new uint8_t[buf_size];
 
-    if ((*this)[network_id]->Serialize(data, size) != size) {
+    if (items[network_id]->Serialize(data, buf_size) != buf_size) {
         ESP_LOGE(TAG_Ladder, "Duplicate serialize error");
         delete[] data;
         return;
     }
 
     auto new_network = new Network();
-    size_t network_readed = new_network->Deserialize(data, size);
+    size_t network_readed = new_network->Deserialize(data, buf_size);
     delete[] data;
     if (network_readed == 0) {
         ESP_LOGE(TAG_Ladder, "Duplicate deserialize error");
@@ -84,23 +96,23 @@ void Ladder::Duplicate(int network_id) {
         return;
     }
 
-    auto pos = begin();
-    insert(std::next(pos, network_id), new_network);
+    auto pos = items.begin();
+    items.insert(std::next(pos, network_id), new_network);
     frame_buffer_req_render = true;
 }
 
 void Ladder::Delete(int network_id) {
-    auto pos = begin();
+    auto pos = items.begin();
     auto it = std::next(pos, network_id);
     auto network = *it;
-    erase(it);
+    items.erase(it);
     delete network;
     frame_buffer_req_render = true;
 }
 
 void Ladder::SetViewTopIndex(int32_t index) {
     ESP_LOGI(TAG_Ladder, "SetViewTopIndex, index:%d", index);
-    if (index < 0 || index + Ladder::MaxViewPortCount > size()) {
+    if (index < 0 || index + Ladder::MaxViewPortCount > items.size()) {
         return;
     }
     view_top_index = index;
@@ -117,7 +129,7 @@ void Ladder::SetSelectedNetworkIndex(int32_t index) {
              (unsigned)view_top_index,
              selected_network,
              index);
-    if (index < 0 || index >= (int)size()) {
+    if (index < 0 || index >= (int)items.size()) {
         return;
     }
 
@@ -125,14 +137,14 @@ void Ladder::SetSelectedNetworkIndex(int32_t index) {
 
     switch (design_state) {
         case EditableElement::ElementState::des_Regular:
-            (*this)[index]->Select();
+            items[index]->Select();
             Controller::DesignStart();
             break;
 
         case EditableElement::ElementState::des_Selected:
-            (*this)[selected_network]->CancelSelection();
+            items[selected_network]->CancelSelection();
 
-            (*this)[index]->Select();
+            items[index]->Select();
             break;
 
         case EditableElement::ElementState::des_Editing:
@@ -165,7 +177,7 @@ void Ladder::SetSelectedNetworkIndex(int32_t index) {
 }
 
 void Ladder::AtLeastOneNetwork() {
-    if (!empty()) {
+    if (!items.empty()) {
         return;
     }
     ESP_LOGI(TAG_Ladder, "requires at least one network");

--- a/PLC_esp8266/main/LogicProgram/Ladder.cpp
+++ b/PLC_esp8266/main/LogicProgram/Ladder.cpp
@@ -19,18 +19,6 @@ Ladder::~Ladder() {
     RemoveAll();
 }
 
-size_t Ladder::size() const {
-    return items.size();
-}
-
-Network *&Ladder::operator[](size_t index) {
-    return items[index];
-}
-
-Network *const &Ladder::operator[](size_t index) const {
-    return items[index];
-}
-
 void Ladder::RemoveAll() {
     while (!items.empty()) {
         auto it = items.begin();

--- a/PLC_esp8266/main/LogicProgram/Ladder.h
+++ b/PLC_esp8266/main/LogicProgram/Ladder.h
@@ -12,8 +12,9 @@
 
 #define LADDER_VERSION ((uint32_t)0x20240905)
 
-class Ladder : public std::vector<Network *> {
+class Ladder {
   protected:
+    std::vector<Network *> items;
     int32_t view_top_index;
     bool frame_buffer_req_render;
 
@@ -33,6 +34,10 @@ class Ladder : public std::vector<Network *> {
 
     explicit Ladder();
     ~Ladder();
+
+    size_t size() const;
+    Network *&operator[](size_t index);
+    Network *const &operator[](size_t index) const;
 
     bool DoAction();
     void Render(FrameBuffer *fb);

--- a/PLC_esp8266/main/LogicProgram/Ladder.h
+++ b/PLC_esp8266/main/LogicProgram/Ladder.h
@@ -35,10 +35,6 @@ class Ladder {
     explicit Ladder();
     ~Ladder();
 
-    size_t size() const;
-    Network *&operator[](size_t index);
-    Network *const &operator[](size_t index) const;
-
     bool DoAction();
     void Render(FrameBuffer *fb);
     void AtLeastOneNetwork();

--- a/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
+++ b/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
@@ -10,19 +10,19 @@
 #include <string.h>
 
 bool Ladder::CanScrollAuto() {
-    return (size_t)view_top_index == size() - Ladder::MaxViewPortCount;
+    return (size_t)view_top_index == items.size() - Ladder::MaxViewPortCount;
 }
 
 void Ladder::AutoScroll() {
-    if (size() > Ladder::MaxViewPortCount) {
-        view_top_index = size() - Ladder::MaxViewPortCount;
+    if (items.size() > Ladder::MaxViewPortCount) {
+        view_top_index = items.size() - Ladder::MaxViewPortCount;
         Controller::UpdateUIViewTop(view_top_index);
     }
 }
 
 int Ladder::GetSelectedNetwork() {
-    for (int i = 0; i < (int)size(); i++) {
-        auto network = (*this)[i];
+    for (int i = 0; i < (int)items.size(); i++) {
+        auto network = items[i];
         switch (network->GetEditable_state()) {
             case EditableElement::ElementState::des_Selected:
             case EditableElement::ElementState::des_Editing:
@@ -48,7 +48,7 @@ EditableElement::ElementState Ladder::GetDesignState(int selected_network) {
         return EditableElement::ElementState::des_Regular;
     }
 
-    auto network = (*this)[selected_network];
+    auto network = items[selected_network];
     switch (network->GetEditable_state()) {
         case EditableElement::ElementState::des_Selected:
         case EditableElement::ElementState::des_Editing:
@@ -80,20 +80,20 @@ bool Ladder::ScrollUp(int *selected_network) {
         Controller::UpdateUIViewTop(view_top_index);
         Controller::UpdateUISelected(*selected_network);
     }
-    return size() > 0;
+    return items.size() > 0;
 }
 
 bool Ladder::ScrollDown(int *selected_network) {
     if (*selected_network + 1 < view_top_index + (int)Ladder::MaxViewPortCount) {
         (*selected_network)++;
         Controller::UpdateUISelected(*selected_network);
-    } else if (view_top_index + Ladder::MaxViewPortCount <= size()) {
+    } else if (view_top_index + Ladder::MaxViewPortCount <= items.size()) {
         view_top_index++;
         (*selected_network)++;
         Controller::UpdateUIViewTop(view_top_index);
         Controller::UpdateUISelected(*selected_network);
     }
-    return *selected_network < (int)size();
+    return *selected_network < (int)items.size();
 }
 
 void Ladder::HandleButtonUp() {
@@ -116,36 +116,36 @@ void Ladder::HandleButtonUp() {
             break;
 
         case EditableElement::ElementState::des_Selected:
-            (*this)[selected_network]->CancelSelection();
+            items[selected_network]->CancelSelection();
             RemoveNetworkIfEmpty(selected_network);
             if (ScrollUp(&selected_network)) {
-                (*this)[selected_network]->Select();
+                items[selected_network]->Select();
             }
             break;
 
         case EditableElement::ElementState::des_Editing:
-            (*this)[selected_network]->SelectPrior();
+            items[selected_network]->SelectPrior();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectMove:
-            (*this)[selected_network]->SwitchToAdvancedSelectDisable();
+            items[selected_network]->SwitchToAdvancedSelectDisable();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectCopy:
-            (*this)[selected_network]->SwitchToAdvancedSelectMove();
+            items[selected_network]->SwitchToAdvancedSelectMove();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectDelete:
-            (*this)[selected_network]->SwitchToAdvancedSelectCopy();
+            items[selected_network]->SwitchToAdvancedSelectCopy();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectDisable:
-            (*this)[selected_network]->SwitchToAdvancedSelectDelete();
+            items[selected_network]->SwitchToAdvancedSelectDelete();
             break;
 
         case EditableElement::ElementState::des_Moving:
             if (selected_network > 0) {
-                std::swap(at(selected_network), at(selected_network - 1));
+                std::swap(items.at(selected_network), items.at(selected_network - 1));
             }
             ScrollUp(&selected_network);
             break;
@@ -174,7 +174,7 @@ void Ladder::HandleButtonPageUp() {
 
     switch (design_state) {
         case EditableElement::ElementState::des_Editing:
-            (*this)[selected_network]->PageUp();
+            items[selected_network]->PageUp();
             return;
         default:
             HandleButtonUp();
@@ -195,50 +195,50 @@ void Ladder::HandleButtonDown() {
 
     switch (design_state) {
         case EditableElement::ElementState::des_Regular:
-            if (view_top_index + Ladder::MaxViewPortCount < size()) {
+            if (view_top_index + Ladder::MaxViewPortCount < items.size()) {
                 view_top_index++;
                 Controller::UpdateUIViewTop(view_top_index);
             }
             break;
 
         case EditableElement::ElementState::des_Selected:
-            (*this)[selected_network]->CancelSelection();
+            items[selected_network]->CancelSelection();
 
             if (!RemoveNetworkIfEmpty(selected_network)) {
                 ScrollDown(&selected_network);
             }
 
-            if (selected_network == (int)size()) {
+            if (selected_network == (int)items.size()) {
                 auto new_network = new Network(LogicItemState::lisActive);
                 Append(new_network);
             }
 
-            (*this)[selected_network]->Select();
+            items[selected_network]->Select();
             break;
 
         case EditableElement::ElementState::des_Editing:
-            (*this)[selected_network]->SelectNext();
+            items[selected_network]->SelectNext();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectMove:
-            (*this)[selected_network]->SwitchToAdvancedSelectCopy();
+            items[selected_network]->SwitchToAdvancedSelectCopy();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectCopy:
-            (*this)[selected_network]->SwitchToAdvancedSelectDelete();
+            items[selected_network]->SwitchToAdvancedSelectDelete();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectDelete:
-            (*this)[selected_network]->SwitchToAdvancedSelectDisable();
+            items[selected_network]->SwitchToAdvancedSelectDisable();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectDisable:
-            (*this)[selected_network]->SwitchToAdvancedSelectMove();
+            items[selected_network]->SwitchToAdvancedSelectMove();
             break;
 
         case EditableElement::ElementState::des_Moving:
-            if (selected_network + 1 < (int)size()) {
-                std::swap(at(selected_network), at(selected_network + 1));
+            if (selected_network + 1 < (int)items.size()) {
+                std::swap(items.at(selected_network), items.at(selected_network + 1));
             }
             ScrollDown(&selected_network);
             break;
@@ -267,7 +267,7 @@ void Ladder::HandleButtonPageDown() {
 
     switch (design_state) {
         case EditableElement::ElementState::des_Editing:
-            (*this)[selected_network]->PageDown();
+            items[selected_network]->PageDown();
             return;
         default:
             HandleButtonDown();
@@ -288,7 +288,7 @@ void Ladder::HandleButtonSelect() {
 
     switch (design_state) {
         case EditableElement::ElementState::des_Regular: {
-            if (size() == 0) {
+            if (items.size() == 0) {
                 auto new_network = new Network(LogicItemState::lisActive);
                 Append(new_network);
             }
@@ -299,10 +299,10 @@ void Ladder::HandleButtonSelect() {
                            view_top_index,
                            (view_top_index + (int)Ladder::MaxViewPortCount) - 1);
 
-            if (last_selected_network >= 0 && last_selected_network < (int)size()) {
-                (*this)[last_selected_network]->Select();
+            if (last_selected_network >= 0 && last_selected_network < (int)items.size()) {
+                items[last_selected_network]->Select();
             } else {
-                (*this)[view_top_index]->Select();
+                items[view_top_index]->Select();
                 Controller::UpdateUISelected(view_top_index);
             }
             Controller::DesignStart();
@@ -310,13 +310,13 @@ void Ladder::HandleButtonSelect() {
         }
 
         case EditableElement::ElementState::des_Selected:
-            (*this)[selected_network]->BeginEditing();
+            items[selected_network]->BeginEditing();
             Controller::UpdateUISelected(selected_network);
             break;
 
         case EditableElement::ElementState::des_Editing:
-            (*this)[selected_network]->Change();
-            if (!(*this)[selected_network]->Editing()) {
+            items[selected_network]->Change();
+            if (!items[selected_network]->Editing()) {
                 if (RemoveNetworkIfEmpty(selected_network)) {
                     selected_network = -1;
                 }
@@ -327,44 +327,44 @@ void Ladder::HandleButtonSelect() {
             return;
 
         case EditableElement::ElementState::des_AdvancedSelectMove:
-            (*this)[selected_network]->SwitchToMoving();
+            items[selected_network]->SwitchToMoving();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectCopy:
-            (*this)[selected_network]->SwitchToCopying();
+            items[selected_network]->SwitchToCopying();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectDelete:
-            (*this)[selected_network]->SwitchToDeleting();
+            items[selected_network]->SwitchToDeleting();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectDisable:
-            (*this)[selected_network]->SwitchToDisabling();
+            items[selected_network]->SwitchToDisabling();
             break;
 
         case EditableElement::ElementState::des_Moving:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Store();
             Controller::DesignEnd();
             break;
 
         case EditableElement::ElementState::des_Copying:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Duplicate(selected_network);
             Store();
             Controller::DesignEnd();
             break;
 
         case EditableElement::ElementState::des_Deleting:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Delete(selected_network);
             Store();
             Controller::DesignEnd();
             break;
 
         case EditableElement::ElementState::des_Disabling:
-            (*this)[selected_network]->EndEditing();
-            (*this)[selected_network]->SwitchState();
+            items[selected_network]->EndEditing();
+            items[selected_network]->SwitchState();
             Store();
             Controller::DesignEnd();
             break;
@@ -385,50 +385,50 @@ void Ladder::HandleButtonOption() {
              selected_network);
     switch (design_state) {
         case EditableElement::ElementState::des_Editing:
-            (*this)[selected_network]->Option();
+            items[selected_network]->Option();
             break;
 
         case EditableElement::ElementState::des_Selected:
-            (*this)[selected_network]->SwitchToAdvancedSelectMove();
+            items[selected_network]->SwitchToAdvancedSelectMove();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectMove:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Controller::DesignEnd();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectCopy:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Controller::DesignEnd();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectDelete:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Controller::DesignEnd();
             break;
 
         case EditableElement::ElementState::des_AdvancedSelectDisable:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Controller::DesignEnd();
             break;
 
         case EditableElement::ElementState::des_Moving:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Controller::DesignEnd();
             break;
 
         case EditableElement::ElementState::des_Copying:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Controller::DesignEnd();
             break;
 
         case EditableElement::ElementState::des_Deleting:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Controller::DesignEnd();
             break;
 
         case EditableElement::ElementState::des_Disabling:
-            (*this)[selected_network]->EndEditing();
+            items[selected_network]->EndEditing();
             Controller::DesignEnd();
             break;
 
@@ -438,11 +438,11 @@ void Ladder::HandleButtonOption() {
 }
 
 bool Ladder::RemoveNetworkIfEmpty(int network_id) {
-    auto network = (*this)[network_id];
+    auto network = items[network_id];
     if (network->empty()) {
-        for (auto it = begin(); it != end(); ++it) {
+        for (auto it = items.begin(); it != items.end(); ++it) {
             if (network == *it) {
-                erase(it);
+                items.erase(it);
                 ESP_LOGI(TAG_Ladder, "delete network: %p", network);
                 delete network;
                 return true;

--- a/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
+++ b/PLC_esp8266/main/LogicProgram/LadderDesigner.cpp
@@ -439,7 +439,7 @@ void Ladder::HandleButtonOption() {
 
 bool Ladder::RemoveNetworkIfEmpty(int network_id) {
     auto network = items[network_id];
-    if (network->empty()) {
+    if (network->Empty()) {
         for (auto it = items.begin(); it != items.end(); ++it) {
             if (network == *it) {
                 items.erase(it);

--- a/PLC_esp8266/main/LogicProgram/LadderStoring.cpp
+++ b/PLC_esp8266/main/LogicProgram/LadderStoring.cpp
@@ -70,7 +70,7 @@ size_t Ladder::Deserialize(uint8_t *buffer, size_t buffer_size) {
         return 0;
     }
 
-    reserve(networks_count);
+    items.reserve(networks_count);
     for (size_t i = 0; i < networks_count; i++) {
         auto network = new Network();
         size_t network_readed = network->Deserialize(&buffer[readed], buffer_size - readed);
@@ -88,7 +88,7 @@ size_t Ladder::Deserialize(uint8_t *buffer, size_t buffer_size) {
 size_t Ladder::Serialize(uint8_t *buffer, size_t buffer_size) {
     size_t writed = 0;
 
-    uint16_t networks_count = size();
+    uint16_t networks_count = items.size();
     if (networks_count < Ladder::MinNetworksCount) {
         return 0;
     }
@@ -100,7 +100,7 @@ size_t Ladder::Serialize(uint8_t *buffer, size_t buffer_size) {
         return 0;
     }
 
-    for (auto it = begin(); it != end(); ++it) {
+    for (auto it = items.begin(); it != items.end(); ++it) {
         auto *network = *it;
         uint8_t *p;
         bool just_obtain_size = buffer == NULL;

--- a/PLC_esp8266/main/LogicProgram/Network.cpp
+++ b/PLC_esp8266/main/LogicProgram/Network.cpp
@@ -24,13 +24,33 @@ Network::Network() : Network(LogicItemState::lisPassive) {
 }
 
 Network::~Network() {
-    while (!empty()) {
-        auto it = begin();
+    while (!items.empty()) {
+        auto it = items.begin();
         auto element = *it;
-        erase(it);
+        items.erase(it);
         ESP_LOGD(TAG_Network, "delete elem: %p", element);
         delete element;
     }
+}
+
+size_t Network::size() const {
+    return items.size();
+}
+
+bool Network::empty() const {
+    return items.empty();
+}
+
+LogicElement *&Network::operator[](size_t index) {
+    return items[index];
+}
+
+LogicElement *const &Network::operator[](size_t index) const {
+    return items[index];
+}
+
+LogicElement *&Network::at(size_t index) {
+    return items.at(index);
 }
 
 void Network::ChangeState(LogicItemState state) {
@@ -48,7 +68,7 @@ bool Network::DoAction() {
     state_changed = false;
     LogicItemState prev_elem_state = state;
 
-    for (auto it = begin(); it != end(); ++it) {
+    for (auto it = items.begin(); it != items.end(); ++it) {
         auto element = *it;
         prev_elem_changed = element->DoAction(prev_elem_changed, prev_elem_state);
         prev_elem_state = element->state;
@@ -80,8 +100,8 @@ IRAM_ATTR void Network::Render(FrameBuffer *fb, uint8_t network_number) {
     LogicItemState prev_elem_state = state;
     start_point.x += INCOME_RAIL_WIDTH;
 
-    auto it = begin();
-    while (it != end()) {
+    auto it = items.begin();
+    while (it != items.end()) {
         auto element = *it;
         if (IsOutputElement(element->GetElementType())) {
             break;
@@ -101,7 +121,7 @@ IRAM_ATTR void Network::Render(FrameBuffer *fb, uint8_t network_number) {
     }
 
     Point end_point = { OUTCOME_RAIL_RIGHT, start_point.y };
-    while (it != end()) {
+    while (it != items.end()) {
         auto element = *it;
         if (!IsOutputElement(element->GetElementType())) {
             auto *continuationIn = ContinuationIn::TryToCast(element);
@@ -138,13 +158,13 @@ IRAM_ATTR void Network::Render(FrameBuffer *fb, uint8_t network_number) {
 
 void Network::Append(LogicElement *element) {
     ESP_LOGD(TAG_Network, "append elem: %p", element);
-    push_back(element);
+    items.push_back(element);
 }
 
 size_t Network::Serialize(uint8_t *buffer, size_t buffer_size) {
     size_t writed = 0;
 
-    uint16_t elements_count = size();
+    uint16_t elements_count = items.size();
     if (elements_count < Network::MinElementsCount) {
         return 0;
     }
@@ -160,7 +180,7 @@ size_t Network::Serialize(uint8_t *buffer, size_t buffer_size) {
         return 0;
     }
 
-    for (auto it = begin(); it != end(); ++it) {
+    for (auto it = items.begin(); it != items.end(); ++it) {
         auto *element = *it;
         uint8_t *p;
         bool just_obtain_size = buffer == NULL;
@@ -204,7 +224,7 @@ size_t Network::Deserialize(uint8_t *buffer, size_t buffer_size) {
     }
 
     state = _state;
-    reserve(elements_count);
+    items.reserve(elements_count);
     for (size_t i = 0; i < elements_count; i++) {
         TvElement tvElement;
         if (!Record::Read(&tvElement, sizeof(tvElement), buffer, buffer_size, &readed)) {
@@ -231,18 +251,18 @@ void Network::SelectPrior() {
     auto selected_element = GetSelectedElement();
 
     if (selected_element >= 0) {
-        if ((*this)[selected_element]->Editing()) {
-            static_cast<ElementsBox *>((*this)[selected_element])->SelectPrior();
+        if (items[selected_element]->Editing()) {
+            static_cast<ElementsBox *>(items[selected_element])->SelectPrior();
             return;
         }
-        (*this)[selected_element]->CancelSelection();
+        items[selected_element]->CancelSelection();
     }
     selected_element--;
     if (selected_element < -1) {
-        selected_element = size() - 1;
+        selected_element = items.size() - 1;
     }
     if (selected_element >= 0) {
-        (*this)[selected_element]->Select();
+        items[selected_element]->Select();
     }
 
     ESP_LOGI(TAG_Network,
@@ -255,17 +275,17 @@ void Network::SelectNext() {
     auto selected_element = GetSelectedElement();
 
     if (selected_element >= 0) {
-        if ((*this)[selected_element]->Editing()) {
-            static_cast<ElementsBox *>((*this)[selected_element])->SelectNext();
+        if (items[selected_element]->Editing()) {
+            static_cast<ElementsBox *>(items[selected_element])->SelectNext();
             return;
         }
-        (*this)[selected_element]->CancelSelection();
+        items[selected_element]->CancelSelection();
     }
     selected_element++;
-    if (selected_element >= (int)size()) {
+    if (selected_element >= (int)items.size()) {
         selected_element = -1;
     } else {
-        (*this)[selected_element]->Select();
+        items[selected_element]->Select();
     }
 
     ESP_LOGI(TAG_Network,
@@ -278,8 +298,8 @@ void Network::PageUp() {
     auto selected_element = GetSelectedElement();
 
     if (selected_element >= 0) {
-        if ((*this)[selected_element]->Editing()) {
-            static_cast<ElementsBox *>((*this)[selected_element])->PageUp();
+        if (items[selected_element]->Editing()) {
+            static_cast<ElementsBox *>(items[selected_element])->PageUp();
             return;
         }
     }
@@ -289,8 +309,8 @@ void Network::PageDown() {
     auto selected_element = GetSelectedElement();
 
     if (selected_element >= 0) {
-        if ((*this)[selected_element]->Editing()) {
-            static_cast<ElementsBox *>((*this)[selected_element])->PageDown();
+        if (items[selected_element]->Editing()) {
+            static_cast<ElementsBox *>(items[selected_element])->PageDown();
             return;
         }
     }
@@ -298,7 +318,7 @@ void Network::PageDown() {
 
 bool Network::OptionShowOutputElement(LogicElement *selected_element) {
     bool last_is_ContinuationIn =
-        selected_element != back() && ContinuationIn::TryToCast(back()) != NULL;
+        selected_element != items.back() && ContinuationIn::TryToCast(items.back()) != NULL;
     if (last_is_ContinuationIn) {
         return false;
     }
@@ -314,16 +334,16 @@ bool Network::OptionShowOutputElement(LogicElement *selected_element) {
 }
 
 bool Network::OptionShowContinuationIn(LogicElement *selected_element) {
-    if (selected_element == back()) {
+    if (selected_element == items.back()) {
         return true;
     }
 
-    bool last_is_wire = Wire::TryToCast(back()) != NULL;
+    bool last_is_wire = Wire::TryToCast(items.back()) != NULL;
     if (!last_is_wire) {
         return false;
     }
 
-    bool is_before_last = size() >= 2 && (selected_element == *(rbegin() + 1));
+    bool is_before_last = items.size() >= 2 && (selected_element == *(items.rbegin() + 1));
     if (is_before_last) {
         return true;
     }
@@ -331,7 +351,7 @@ bool Network::OptionShowContinuationIn(LogicElement *selected_element) {
 }
 
 bool Network::OptionShowContinuationOut(LogicElement *selected_element) {
-    return selected_element == front();
+    return selected_element == items.front();
 }
 
 void Network::Change() {
@@ -347,33 +367,33 @@ void Network::Change() {
         return;
     }
 
-    if ((*this)[selected_element]->Selected()) {
-        auto source_element = (*this)[selected_element];
+    if (items[selected_element]->Selected()) {
+        auto source_element = items[selected_element];
         ElementsBox::Options options{};
-        if (OptionShowOutputElement((*this)[selected_element])) {
+        if (OptionShowOutputElement(items[selected_element])) {
             options = (ElementsBox::Options)(options | ElementsBox::Options::show_output_elements);
         }
-        if (OptionShowContinuationIn((*this)[selected_element])) {
+        if (OptionShowContinuationIn(items[selected_element])) {
             options = (ElementsBox::Options)(options | ElementsBox::Options::show_continuation_in);
         }
-        if (OptionShowContinuationOut((*this)[selected_element])) {
+        if (OptionShowContinuationOut(items[selected_element])) {
             options = (ElementsBox::Options)(options | ElementsBox::Options::show_continuation_out);
         }
 
         ESP_LOGI(TAG_Network, "ElementsBox::Options:0x%08X", options);
         auto elementBox = new ElementsBox(fill_wire, source_element, options);
         elementBox->BeginEditing();
-        (*this)[selected_element] = elementBox;
+        items[selected_element] = elementBox;
 
-    } else if ((*this)[selected_element]->Editing()) {
-        auto elementBox = static_cast<ElementsBox *>((*this)[selected_element]);
+    } else if (items[selected_element]->Editing()) {
+        auto elementBox = static_cast<ElementsBox *>(items[selected_element]);
 
         elementBox->Change();
         if (elementBox->EditingCompleted()) {
             elementBox->EndEditing();
             auto editedElement = elementBox->GetSelectedElement();
             delete elementBox;
-            (*this)[selected_element] = editedElement;
+            items[selected_element] = editedElement;
 
             RemoveSpaceForNewElement();
             AddSpaceForNewElement();
@@ -405,8 +425,8 @@ void Network::AddSpaceForNewElement() {
     if (EnoughSpaceForNewElement(wire)) {
         ESP_LOGI(TAG_Network, "insert wire element");
         LogicItemState wire_state = state;
-        auto it = begin();
-        while (it != end()) {
+        auto it = items.begin();
+        while (it != items.end()) {
             auto element = *it;
             if (IsOutputElement(element->GetElementType())) {
                 break;
@@ -419,7 +439,7 @@ void Network::AddSpaceForNewElement() {
             it++;
         }
         wire->state = wire_state;
-        insert(it, wire);
+        items.insert(it, wire);
 
     } else {
         delete wire;
@@ -427,13 +447,13 @@ void Network::AddSpaceForNewElement() {
 }
 
 void Network::RemoveSpaceForNewElement() {
-    auto it = begin();
-    while (it != end()) {
+    auto it = items.begin();
+    while (it != items.end()) {
         auto element = *it;
         auto as_wire = Wire::TryToCast(element);
         if (as_wire != NULL) {
             fill_wire += as_wire->GetWidth();
-            it = erase(it);
+            it = items.erase(it);
             delete as_wire;
             ESP_LOGI(TAG_Network, "remove wire element");
         } else {
@@ -443,7 +463,7 @@ void Network::RemoveSpaceForNewElement() {
 }
 
 bool Network::HasOutputElement() {
-    for (auto it = begin(); it != end(); ++it) {
+    for (auto it = items.begin(); it != items.end(); ++it) {
         auto element = *it;
         if (IsOutputElement(element->GetElementType())) {
             return true;
@@ -462,7 +482,7 @@ void Network::BeginEditing() {
 void Network::EndEditing() {
     auto selected_element = GetSelectedElement();
     if (selected_element >= 0) {
-        (*this)[selected_element]->CancelSelection();
+        items[selected_element]->CancelSelection();
     }
 
     ESP_LOGI(TAG_Network, "EndEditing");
@@ -476,14 +496,14 @@ void Network::Option() {
 
     ESP_LOGI(TAG_Network, "Option, selected_element:%d", selected_element);
     if (selected_element >= 0) {
-        if ((*this)[selected_element]->Editing()) {
-            auto elementBox = static_cast<ElementsBox *>((*this)[selected_element]);
+        if (items[selected_element]->Editing()) {
+            auto elementBox = static_cast<ElementsBox *>(items[selected_element]);
             elementBox->Option();
             if (elementBox->EditingCompleted()) {
                 elementBox->EndEditing();
                 auto editedElement = elementBox->GetSelectedElement();
                 delete elementBox;
-                (*this)[selected_element] = editedElement;
+                items[selected_element] = editedElement;
 
                 RemoveSpaceForNewElement();
                 AddSpaceForNewElement();
@@ -494,8 +514,8 @@ void Network::Option() {
 }
 
 int Network::GetSelectedElement() {
-    for (int i = 0; i < (int)size(); i++) {
-        auto element = (*this)[i];
+    for (int i = 0; i < (int)items.size(); i++) {
+        auto element = items[i];
         if (element->Selected() || element->Editing()) {
             return i;
         }

--- a/PLC_esp8266/main/LogicProgram/Network.cpp
+++ b/PLC_esp8266/main/LogicProgram/Network.cpp
@@ -33,12 +33,16 @@ Network::~Network() {
     }
 }
 
-size_t Network::size() const {
+bool Network::Empty() const {
+    return items.empty();
+}
+
+size_t Network::Size() const {
     return items.size();
 }
 
-bool Network::empty() const {
-    return items.empty();
+LogicElement *&Network::At(size_t index) {
+    return items.at(index);
 }
 
 LogicElement *&Network::operator[](size_t index) {
@@ -47,10 +51,6 @@ LogicElement *&Network::operator[](size_t index) {
 
 LogicElement *const &Network::operator[](size_t index) const {
     return items[index];
-}
-
-LogicElement *&Network::at(size_t index) {
-    return items.at(index);
 }
 
 void Network::ChangeState(LogicItemState state) {

--- a/PLC_esp8266/main/LogicProgram/Network.h
+++ b/PLC_esp8266/main/LogicProgram/Network.h
@@ -30,11 +30,11 @@ class Network : public EditableElement {
     explicit Network(LogicItemState state);
     virtual ~Network();
 
-    size_t size() const;
-    bool empty() const;
+    bool Empty() const;
+    size_t Size() const;
+    LogicElement *&At(size_t index);
     LogicElement *&operator[](size_t index);
     LogicElement *const &operator[](size_t index) const;
-    LogicElement *&at(size_t index);
 
     void ChangeState(LogicItemState state);
     LogicItemState GetState();

--- a/PLC_esp8266/main/LogicProgram/Network.h
+++ b/PLC_esp8266/main/LogicProgram/Network.h
@@ -7,8 +7,9 @@
 #include <unistd.h>
 #include <vector>
 
-class Network : public std::vector<LogicElement *>, public EditableElement {
+class Network : public EditableElement {
   protected:
+    std::vector<LogicElement *> items;
     LogicItemState state;
     bool state_changed;
     bool frame_buffer_req_render;
@@ -28,6 +29,12 @@ class Network : public std::vector<LogicElement *>, public EditableElement {
     explicit Network();
     explicit Network(LogicItemState state);
     virtual ~Network();
+
+    size_t size() const;
+    bool empty() const;
+    LogicElement *&operator[](size_t index);
+    LogicElement *const &operator[](size_t index) const;
+    LogicElement *&at(size_t index);
 
     void ChangeState(LogicItemState state);
     LogicItemState GetState();

--- a/PLC_esp8266/main/WiFi/WiFiRequests.cpp
+++ b/PLC_esp8266/main/WiFi/WiFiRequests.cpp
@@ -95,45 +95,14 @@ bool WiFiRequests::Pop(RequestItem *request) {
     return true;
 }
 
-size_t WiFiRequests::GetSize() const {
-    return items.size();
-}
-
-const RequestItem &WiFiRequests::GetBack() const {
-    return items.back();
-}
-
-void WiFiRequests::PopBack() {
-    items.pop_back();
-}
-
-std::list<RequestItem>::iterator WiFiRequests::GetBegin() {
-    return items.begin();
-}
-
-std::list<RequestItem>::iterator WiFiRequests::GetEnd() {
-    return items.end();
-}
-
-std::list<RequestItem>::const_iterator WiFiRequests::GetBegin() const {
-    return items.begin();
-}
-
-std::list<RequestItem>::const_iterator WiFiRequests::GetEnd() const {
-    return items.end();
-}
-
 size_t WiFiRequests::Size() const {
-    std::lock_guard<std::mutex> lock(lock_mutex);
     return items.size();
 }
 
 std::list<RequestItem>::const_iterator WiFiRequests::Begin() const {
-    std::lock_guard<std::mutex> lock(lock_mutex);
     return items.begin();
 }
 
 std::list<RequestItem>::const_iterator WiFiRequests::End() const {
-    std::lock_guard<std::mutex> lock(lock_mutex);
     return items.end();
 }

--- a/PLC_esp8266/main/WiFi/WiFiRequests.h
+++ b/PLC_esp8266/main/WiFi/WiFiRequests.h
@@ -48,14 +48,6 @@ class WiFiRequests {
     bool Equals(const RequestItem *a, const RequestItem *b) const;
     std::list<RequestItem>::iterator Find(RequestItem *request);
 
-    size_t GetSize() const;
-    const RequestItem &GetBack() const;
-    void PopBack();
-    std::list<RequestItem>::iterator GetBegin();
-    std::list<RequestItem>::iterator GetEnd();
-    std::list<RequestItem>::const_iterator GetBegin() const;
-    std::list<RequestItem>::const_iterator GetEnd() const;
-
   public:
     bool Contains(RequestItem *request);
     bool HasAnother(RequestItem *current);

--- a/PLC_esp8266/main/WiFi/WiFiRequests.h
+++ b/PLC_esp8266/main/WiFi/WiFiRequests.h
@@ -42,10 +42,8 @@ struct RequestItem {
 };
 
 class WiFiRequests {
-  private:
-    std::list<RequestItem> items;
-
   protected:
+    std::list<RequestItem> items;
     mutable std::mutex lock_mutex;
     bool Equals(const RequestItem *a, const RequestItem *b) const;
     std::list<RequestItem>::iterator Find(RequestItem *request);

--- a/Tests_esp8266/src/WiFiRequests_tests.cpp
+++ b/Tests_esp8266/src/WiFiRequests_tests.cpp
@@ -23,17 +23,8 @@ namespace {
             return Equals(a, b);
         }
 
-        size_t PublicMorozov_size() const {
-            return GetSize();
-        }
         const RequestItem &PublicMorozov_back() const {
-            return GetBack();
-        }
-        std::list<RequestItem>::iterator PublicMorozov_begin() {
-            return GetBegin();
-        }
-        std::list<RequestItem>::iterator PublicMorozov_end() {
-            return GetEnd();
+            return items.back();
         }
     };
 } // namespace
@@ -120,15 +111,15 @@ TEST(WiFiRequestsTestsGroup, Equals_by_AccessPoint_payload) {
 TEST(WiFiRequestsTestsGroup, Scan_is_unique) {
     TestableWiFiRequests testable;
 
-    CHECK_EQUAL(0, testable.PublicMorozov_size());
+    CHECK_EQUAL(0, testable.Size());
 
     const char *ssid = "test";
 
     testable.Scan(ssid);
-    CHECK_EQUAL(1, testable.PublicMorozov_size());
+    CHECK_EQUAL(1, testable.Size());
 
     testable.Scan(ssid);
-    CHECK_EQUAL(1, testable.PublicMorozov_size());
+    CHECK_EQUAL(1, testable.Size());
     CHECK_EQUAL(RequestItemType::wqi_Scanner, testable.PublicMorozov_back().Type);
     CHECK_EQUAL(ssid, testable.PublicMorozov_back().Payload.Scanner.ssid);
 }
@@ -144,32 +135,32 @@ TEST(WiFiRequestsTestsGroup, Pop_is_queue_compliant) {
     testable.AccessPoint(ssid_0, NULL, NULL);
     testable.Scan(ssid_1);
     testable.AccessPoint(ssid_1, NULL, NULL);
-    CHECK_EQUAL(5, testable.PublicMorozov_size());
+    CHECK_EQUAL(5, testable.Size());
 
     RequestItem request;
     CHECK_TRUE(testable.Pop(&request));
     CHECK_EQUAL(RequestItemType::wqi_Station, request.Type);
-    CHECK_EQUAL(4, testable.PublicMorozov_size());
+    CHECK_EQUAL(4, testable.Size());
 
     CHECK_TRUE(testable.Pop(&request));
     CHECK_EQUAL(RequestItemType::wqi_Scanner, request.Type);
     STRCMP_EQUAL("test_0", request.Payload.Scanner.ssid);
-    CHECK_EQUAL(3, testable.PublicMorozov_size());
+    CHECK_EQUAL(3, testable.Size());
 
     CHECK_TRUE(testable.Pop(&request));
     CHECK_EQUAL(RequestItemType::wqi_AccessPoint, request.Type);
     STRCMP_EQUAL("test_0", request.Payload.AccessPoint.ssid);
-    CHECK_EQUAL(2, testable.PublicMorozov_size());
+    CHECK_EQUAL(2, testable.Size());
 
     CHECK_TRUE(testable.Pop(&request));
     CHECK_EQUAL(RequestItemType::wqi_Scanner, request.Type);
     STRCMP_EQUAL("test_1", request.Payload.Scanner.ssid);
-    CHECK_EQUAL(1, testable.PublicMorozov_size());
+    CHECK_EQUAL(1, testable.Size());
 
     CHECK_TRUE(testable.Pop(&request));
     CHECK_EQUAL(RequestItemType::wqi_AccessPoint, request.Type);
     STRCMP_EQUAL("test_1", request.Payload.AccessPoint.ssid);
-    CHECK_EQUAL(0, testable.PublicMorozov_size());
+    CHECK_EQUAL(0, testable.Size());
 }
 
 TEST(WiFiRequestsTestsGroup, HasAnother_when_current_is_Station) {

--- a/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
+++ b/Tests_esp8266/src/logic_LadderDesigner_tests.cpp
@@ -64,6 +64,15 @@ namespace {
         bool PublicMorozov_RemoveNetworkIfEmpty(int network_id) {
             return RemoveNetworkIfEmpty(network_id);
         }
+        size_t size() const {
+            return items.size();
+        }
+        Network *&operator[](size_t index) {
+            return items[index];
+        }
+        Network *const &operator[](size_t index) const {
+            return items[index];
+        }
     };
 
     class TestableNetwork : public Network {
@@ -359,12 +368,12 @@ TEST(LogicLadderDesignerTestsGroup, HandleButtonSelect_calls_store_after_network
 
     testable.HandleButtonSelect();
 
-    Ladder ladder_load;
+    TestableLadder ladder_load;
     ladder_load.Load();
 
     CHECK_EQUAL(1, ladder_load.size());
     auto network_load = ladder_load[0];
-    CHECK_EQUAL(2, network_load->size());
+    CHECK_EQUAL(2, network_load->Size());
     CHECK_EQUAL(TvElementType::et_InputNC, (*network_load)[0]->GetElementType());
     CHECK_EQUAL(MapIO::DI, ((InputNC *)(*network_load)[0])->GetIoAdr());
     CHECK_EQUAL(TvElementType::et_DirectOutput, (*network_load)[1]->GetElementType());
@@ -865,8 +874,8 @@ TEST(LogicLadderDesignerTestsGroup, AdvancedEditing__duplicate_network) {
     testable.HandleButtonSelect();
     CHECK_EQUAL(2, testable.size());
     CHECK_EQUAL(testable[1], network0);
-    CHECK_EQUAL(1, testable[0]->size());
-    CHECK_EQUAL(TvElementType::et_InputNC, testable[0]->at(0)->GetElementType());
+    CHECK_EQUAL(1, testable[0]->Size());
+    CHECK_EQUAL(TvElementType::et_InputNC, testable[0]->At(0)->GetElementType());
 }
 
 TEST(LogicLadderDesignerTestsGroup, AdvancedEditing__delete_network) {

--- a/Tests_esp8266/src/logic_Ladder_tests.cpp
+++ b/Tests_esp8266/src/logic_Ladder_tests.cpp
@@ -45,6 +45,15 @@ namespace {
       public:
         TestableLadder() : Ladder() {
         }
+        size_t size() const {
+            return items.size();
+        }
+        Network *&operator[](size_t index) {
+            return items[index];
+        }
+        Network *const &operator[](size_t index) const {
+            return items[index];
+        }
     };
 
     class TestableNetwork : public Network, public MonitorLogicElement {
@@ -144,7 +153,7 @@ namespace {
 } // namespace
 
 TEST(LogicLadderTestsGroup, Store_Load) {
-    Ladder ladder_store;
+    TestableLadder ladder_store;
 
     auto network_store = new Network(LogicItemState::lisActive);
     ladder_store.Append(network_store);
@@ -155,13 +164,13 @@ TEST(LogicLadderTestsGroup, Store_Load) {
     network_store->Append(new TestableDirectOutput(MapIO::O1));
     ladder_store.Store();
 
-    Ladder ladder_load;
+    TestableLadder ladder_load;
     ladder_load.Load();
 
     CHECK_EQUAL(1, ladder_load.size());
 
     auto network_load = ladder_load[0];
-    CHECK_EQUAL(4, network_load->size());
+    CHECK_EQUAL(4, network_load->Size());
     CHECK_EQUAL(TvElementType::et_InputNC, (*network_load)[0]->GetElementType());
     CHECK_EQUAL(MapIO::DI, ((TestableInputNC *)(*network_load)[0])->GetIoAdr());
     CHECK(&Controller::DI == ((TestableInputNC *)(*network_load)[0])->Input);
@@ -180,7 +189,7 @@ TEST(LogicLadderTestsGroup, Store_Load) {
 }
 
 TEST(LogicLadderTestsGroup, Remove_elements_before_Load) {
-    Ladder ladder_store;
+    TestableLadder ladder_store;
 
     auto network0 = new Network(LogicItemState::lisActive);
     network0->Append(new TestableInputNC(MapIO::DI));
@@ -202,20 +211,20 @@ TEST(LogicLadderTestsGroup, Remove_elements_before_Load) {
     ladder_store.Append(network2);
     ladder_store.Store();
 
-    Ladder ladder_load;
+    TestableLadder ladder_load;
     ladder_load.Append(new Network());
     ladder_load.Append(new Network());
     ladder_load.Load();
 
     CHECK_EQUAL(3, ladder_load.size());
 
-    CHECK_EQUAL(2, ladder_load[0]->size());
-    CHECK_EQUAL(3, ladder_load[1]->size());
-    CHECK_EQUAL(4, ladder_load[2]->size());
+    CHECK_EQUAL(2, ladder_load[0]->Size());
+    CHECK_EQUAL(3, ladder_load[1]->Size());
+    CHECK_EQUAL(4, ladder_load[2]->Size());
 }
 
 TEST(LogicLadderTestsGroup, initial_load_when_empty_storage) {
-    Ladder ladder_load;
+    TestableLadder ladder_load;
     ladder_load.Load();
 
     CHECK_EQUAL(0, ladder_load.size());
@@ -234,7 +243,7 @@ TEST(LogicLadderTestsGroup, Deserialize_with_clear_storage__load_initial) {
                             ladder_storage_name,
                             &storage);
 
-    Ladder ladder_load;
+    TestableLadder ladder_load;
     ladder_load.Load();
     CHECK_EQUAL(0, ladder_load.size());
 }
@@ -407,7 +416,7 @@ TEST(LogicLadderTestsGroup, AtLeastOneNetwork__if_no_networks_then_create_ones_a
 }
 
 TEST(LogicLadderTestsGroup, Delete_storage) {
-    Ladder ladder_store;
+    TestableLadder ladder_store;
 
     auto network_store = new Network(LogicItemState::lisActive);
     ladder_store.Append(network_store);
@@ -420,7 +429,7 @@ TEST(LogicLadderTestsGroup, Delete_storage) {
 
     Ladder::DeleteStorage();
 
-    Ladder ladder_load;
+    TestableLadder ladder_load;
     ladder_load.Load();
 
     CHECK_EQUAL(0, ladder_load.size());

--- a/Tests_esp8266/src/logic_Network_tests.cpp
+++ b/Tests_esp8266/src/logic_Network_tests.cpp
@@ -51,6 +51,16 @@ namespace {
         void PublicMorozov_AddSpaceForNewElement() {
             AddSpaceForNewElement();
         }
+
+        size_t size() const {
+            return items.size();
+        }
+        LogicElement *&operator[](size_t index) {
+            return items[index];
+        }
+        LogicElement *const &operator[](size_t index) const {
+            return items[index];
+        }
     };
 
     class TestableInputNC : public InputNC, public MonitorLogicElement {
@@ -176,7 +186,7 @@ namespace {
 } // namespace
 
 TEST(LogicNetworkTestsGroup, append_elements) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new TestableInputNC);
     testable.Append(new TestableComparatorEq());
@@ -187,7 +197,7 @@ TEST(LogicNetworkTestsGroup, append_elements) {
 }
 
 TEST(LogicNetworkTestsGroup, DoAction_handle_all_logic_elements_in_chain) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new TestableInputNC);
     testable.Append(new TestableComparatorEq());
@@ -203,7 +213,7 @@ TEST(LogicNetworkTestsGroup, DoAction_handle_all_logic_elements_in_chain) {
 }
 
 TEST(LogicNetworkTestsGroup, DoAction_return_changes_from_any_handler_in_chain) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new TestableInputNC);
     testable.Append(new TestableComparatorEq());
@@ -224,7 +234,7 @@ TEST(LogicNetworkTestsGroup, DoAction_return_changes_from_any_handler_in_chain) 
 }
 
 TEST(LogicNetworkTestsGroup, Render_when_active__also_render_all_elements_in_chain) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new TestableInputNC);
     testable.Append(new TestableComparatorEq());
@@ -249,7 +259,7 @@ TEST(LogicNetworkTestsGroup, Render_when_active__also_render_all_elements_in_cha
 }
 
 TEST(LogicNetworkTestsGroup, Render_with_Indicator_element) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new TestableIndicator);
     testable.Render(&frame_buffer, 0);
@@ -266,7 +276,7 @@ TEST(LogicNetworkTestsGroup, Render_with_Indicator_element) {
 }
 
 TEST(LogicNetworkTestsGroup, Render_with_Wire_element) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new TestableWire);
     testable.Render(&frame_buffer, 0);
@@ -283,7 +293,7 @@ TEST(LogicNetworkTestsGroup, Render_with_Wire_element) {
 }
 
 TEST(LogicNetworkTestsGroup, Render_with_WiFiBinding_element) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new TestableWiFiBinding);
     testable.Render(&frame_buffer, 0);
@@ -300,7 +310,7 @@ TEST(LogicNetworkTestsGroup, Render_with_WiFiBinding_element) {
 }
 
 TEST(LogicNetworkTestsGroup, Render_when_passive__also_render_all_elements_in_chain) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new TestableInputNC);
     testable.Append(new TestableComparatorEq());
@@ -326,7 +336,7 @@ TEST(LogicNetworkTestsGroup, Render_when_passive__also_render_all_elements_in_ch
 
 TEST(LogicNetworkTestsGroup,
      Render_inputs_starts_from_start_point_and_render_outputs_starts_from_end) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new TestableInputNC);
     testable.Append(new TestableComparatorEq());
@@ -475,7 +485,7 @@ TEST(LogicNetworkTestsGroup, Deserialize) {
     *((TvElementType *)&buffer[17]) = TvElementType::et_DirectOutput;
     *((MapIO *)&buffer[18]) = MapIO::O1;
 
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     size_t readed = testable.Deserialize(&buffer[0], sizeof(buffer) - 1);
     CHECK_EQUAL(19, readed);
@@ -487,7 +497,7 @@ TEST(LogicNetworkTestsGroup, Deserialize) {
 }
 
 TEST(LogicNetworkTestsGroup, Begin_Editing_and_replacing_selected_element_with_ElementBox) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new InputNC(MapIO::DI));
     testable.Append(new ComparatorEq(1, MapIO::AI));
@@ -508,7 +518,7 @@ TEST(LogicNetworkTestsGroup, Begin_Editing_and_replacing_selected_element_with_E
 }
 
 TEST(LogicNetworkTestsGroup, Begin_Editing_can_hide_output_elements_in_ElementBox) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new InputNC(MapIO::DI));
     testable.Append(new DirectOutput(MapIO::O1));
@@ -536,7 +546,7 @@ TEST(LogicNetworkTestsGroup, Begin_Editing_can_hide_output_elements_in_ElementBo
 
 TEST(LogicNetworkTestsGroup,
      Begin_Editing_not_hide_output_elements_in_ElementBox_if_selected_element_is_output) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new InputNC(MapIO::DI));
     testable.Append(new DirectOutput(MapIO::O1));
@@ -563,7 +573,7 @@ TEST(LogicNetworkTestsGroup,
 }
 
 TEST(LogicNetworkTestsGroup, EndEditing_ElementBox_switch_selection_to_network_self) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new InputNC(MapIO::DI));
     testable.Append(new ComparatorEq(1, MapIO::AI));
@@ -657,7 +667,7 @@ TEST(LogicNetworkTestsGroup, wire_element__take__all__empty_space) {
 }
 
 TEST(LogicNetworkTestsGroup, Wire_elements_must_be_deleted_after_editing) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new InputNC(MapIO::DI));
     testable.Append(new ComparatorEq(1, MapIO::AI));
@@ -692,7 +702,7 @@ TEST(LogicNetworkTestsGroup, Wire_elements_must_be_deleted_after_editing) {
 }
 
 TEST(LogicNetworkTestsGroup, EndEditing_delete_ElementBox) {
-    Network testable(LogicItemState::lisActive);
+    TestableNetwork testable(LogicItemState::lisActive);
 
     testable.Append(new InputNC(MapIO::DI));
     testable.Append(new ComparatorEq(1, MapIO::AI));


### PR DESCRIPTION
This PR refactors the `Ladder` and `Network` classes to use composition instead of inheritance from `std::vector`. This improves encapsulation and makes the API more explicit, following the principle "prefer composition over inheritance."

### Main changes

#### 1. Ladder Class Refactoring

Changed `Ladder` from inheriting `std::vector<Network *>` to containing it as a member variable `items`.

**Key files**: `Ladder.h`, `Ladder.cpp`, `LadderStoring.cpp`, `LadderDesigner.cpp`

Before:

```cpp
class Ladder : public std::vector<Network *> {

```

After:

```cpp
class Ladder {
  protected:
    std::vector<Network *> items;

```

All direct vector method calls (e.g., `begin()`, `end()`, `size()`, `at()`, `push_back()`) are now accessed through the `items` member.

#### 2. Network Class Refactoring

Changed `Network` from inheriting `std::vector<LogicElement *>` to containing it as a member variable `items`. Added explicit accessor methods for cleaner API.

**Key files**: `Network.h`, `Network.cpp`

New public methods:

```cpp
bool Empty() const;
size_t Size() const;
LogicElement *&At(size_t index);
LogicElement *&operator[](size_t index);
LogicElement *const &operator[](size_t index) const;

```

#### 3. WiFiRequests Cleanup

Removed unused wrapper methods that were previously added for encapsulation but never used:

-   `GetSize()`,  `GetBack()`,  `PopBack()`
-   `GetBegin()`,  `GetEnd()`  (both const and non-const versions)

Simplified remaining methods (`Size()`, `Begin()`, `End()`) by removing redundant mutex locks (the lock is already held by callers).

**Key files**: `WiFiRequests.h`, `WiFiRequests.cpp`

#### 4. Tests

Updated tests to work with the new composition-based API:

-   `logic_Ladder_tests.cpp`  — updated to use  `items`  member
-   `logic_Network_tests.cpp`  — updated to use new accessor methods
-   `logic_LadderDesigner_tests.cpp`  — adapted for API changes
-   `WiFiRequests_tests.cpp`  — simplified after removing unused methods